### PR TITLE
feat(languages): python, ruby and php remediation capability fills (4.4.7 V2)

### DIFF
--- a/src/analyzers/correctness/lockfile-check.ts
+++ b/src/analyzers/correctness/lockfile-check.ts
@@ -196,14 +196,22 @@ export function executeLockfileCheck(
       // A further tolerated-class failure with the ladder exhausted keeps
       // the disclosed pass (the pre-fix semantics, now the LAST resort).
       if (notes.length > 0 && retries.some((r) => r.matches(attempt.output))) return pass();
+      // A pack-declared NON-DRIFT classification (poetry check validates
+      // the whole pyproject alongside the lock) replaces the resync remedy
+      // with the pack's own disclosure: the check still fails (the frozen
+      // install fails on this tree either way), but the cause is named so
+      // a manifest error is never read, or remediated, as lockfile drift.
+      const classified = check.classifyFailure?.(attempt.output) ?? null;
       return {
         ...base,
         status: 'fail',
         output:
           tail(attempt.output) +
-          '\nThe lockfile does not satisfy the manifest: a frozen install (what CI runs before ' +
-          'any gate) fails on this tree. Re-run the package manager install so the lockfile ' +
-          'records the manifest, and commit both.',
+          '\n' +
+          (classified ??
+            'The lockfile does not satisfy the manifest: a frozen install (what CI runs before ' +
+              'any gate) fails on this tree. Re-run the package manager install so the lockfile ' +
+              'records the manifest, and commit both.'),
       };
     }
     const [retry] = remaining.splice(idx, 1);

--- a/src/languages/capabilities/correctness.ts
+++ b/src/languages/capabilities/correctness.ts
@@ -222,6 +222,9 @@ export type LockfileCheck =
       readonly kind: 'command';
       readonly command: CorrectnessCommand;
       readonly tolerated?: readonly ToleratedCheckRetry[];
+      /** The strategy's declared non-drift classifier, passed through by
+       *  the one derivation below (see `LockfileSyncCheck`). */
+      readonly classifyFailure?: (output: string) => string | null;
     }
   | { readonly kind: 'skipped'; readonly reason: string };
 
@@ -246,6 +249,7 @@ export function lockfileCheckFromStrategy(
   return {
     kind: 'command',
     command: { label: LOCKFILE_SYNC_LABEL, bin: check.command.bin, args: check.command.args },
+    ...(check.classifyFailure !== undefined ? { classifyFailure: check.classifyFailure } : {}),
     ...(fallbacks.length > 0
       ? {
           // One retry per authorized fallback, its command the dry-run

--- a/src/languages/capabilities/install-strategy.ts
+++ b/src/languages/capabilities/install-strategy.ts
@@ -168,6 +168,16 @@ export type LockfileSyncCheck =
       readonly kind: 'command';
       readonly command: InstallCommand;
       readonly tolerates: readonly ToleranceClass[];
+      /**
+       * OPTIONAL classifier for a failure that is NOT lockfile drift, when
+       * the ecosystem's only check also validates other things (poetry
+       * check validates the whole pyproject alongside the lock). Returns
+       * the full disclosure sentence to print INSTEAD of the resync
+       * remedy, or null for a real drift. Pure; biased toward false
+       * negatives (uncertain output keeps the drift reading, since the
+       * frozen install would fail on it either way).
+       */
+      readonly classifyFailure?: (output: string) => string | null;
     }
   | { readonly kind: 'skipped'; readonly reason: string };
 

--- a/src/languages/capabilities/remediation.ts
+++ b/src/languages/capabilities/remediation.ts
@@ -115,8 +115,46 @@ export type PinPlanResult =
       readonly edit: ManifestTextEdit;
       /** How a human undoes the pin, rendered in ledger prose. */
       readonly revert: string;
+      /** Pack-declared side-effect disclosures the executor carries onto an
+       *  applied outcome's notes (composer's lock resync may refresh
+       *  unrelated packages). Prose the ledger prints verbatim. */
+      readonly notes?: readonly string[];
     }
   | { readonly kind: 'refused'; readonly reason: string };
+
+/**
+ * The ecosystem's version grammar for pinning (Rule 6): which "fixed
+ * version" strings a pack can pin VERBATIM, and how two of them order.
+ * Consumed by the registry's `matches` (a non-concrete fixed version tiers
+ * the order to the agent instead of guessing a range's meaning) and by the
+ * pick of the highest fixed version. Absent, the default is npm's x.y.z
+ * semver shape; ecosystems whose advisories carry other concrete forms
+ * (RubyGems 4-segment security releases, PyPI two-segment releases)
+ * declare their own. Both members are pure and deterministic; `concrete`
+ * biases toward false NEGATIVES (a form the comparator cannot order
+ * confidently is refused, never guessed).
+ */
+export interface PinVersionScheme {
+  /** Is `version` a concrete, pinnable version (never a range, wildcard,
+   *  or an unorderable marker)? */
+  concrete(version: string): boolean;
+  /** Total order over versions `concrete` accepted. */
+  compare(a: string, b: string): number;
+}
+
+/** Numeric dotted-segment comparison (missing segments read as 0): the
+ *  shared comparator for release-only version schemes (RubyGems and PyPI
+ *  concrete releases order this way). */
+export function compareNumericSegments(a: string, b: string): number {
+  const as = a.split('.').map(Number);
+  const bs = b.split('.').map(Number);
+  for (let i = 0; i < Math.max(as.length, bs.length); i++) {
+    const x = as[i] ?? 0;
+    const y = bs[i] ?? 0;
+    if (x !== y) return x - y;
+  }
+  return 0;
+}
 
 export interface PinTransitiveProvider {
   /** Manifest basenames naming the owning root in an envelope (the edit
@@ -125,6 +163,9 @@ export interface PinTransitiveProvider {
   readonly manifestFiles: readonly string[];
   /** OSV ecosystem name for the candidate pre-check (`npm`, `PyPI`, ...). */
   readonly osvEcosystem: string;
+  /** The ecosystem's pinnable-version grammar; absent = the x.y.z semver
+   *  default. */
+  readonly versions?: PinVersionScheme;
   /** Plan the pin at a root: a pure decision (may READ repo files, writes
    *  nothing) yielding the edit + revert prose, or a refusal with the
    *  reason (an override mechanism the pack does not implement yet). */
@@ -173,6 +214,15 @@ export interface DeclareDependencyProvider {
   /** The concrete version out of the probe's output, or null when the
    *  output does not name one. Pure and total over untrusted output. */
   parseProbeOutput(output: string): string | null;
+  /**
+   * Does a FAILED probe's output have an INFRASTRUCTURE shape specific to
+   * this ecosystem's tooling (uv's "No virtual environment found"), so the
+   * executor reports a named failure instead of refusing the specifier as
+   * "likely a typo"? Extends the executor's generic tool-CLI set (unknown
+   * command, command not found). Pure; biased toward false negatives (a
+   * real not-found must never read as infrastructure). Optional.
+   */
+  probeInfrastructure?(output: string): boolean;
   /** The install command declaring `specifier@version` into the manifest
    *  (the dev section when `dev`). */
   installCommand(ctx: DeclareInstallContext): InstallCommand;

--- a/src/languages/php-remediation.ts
+++ b/src/languages/php-remediation.ts
@@ -111,6 +111,16 @@ const phpPinTransitive: PinTransitiveProvider = {
       kind: 'plan',
       edit: { file: 'composer.json', transform: composerRequireTransform(ctx.pkg, ctx.version) },
       revert: `remove the "require" entry for '${ctx.pkg}' from ${at}composer.json and re-run the lock resync`,
+      // Deliberate churn, disclosed on the ledger: composer has no scoped
+      // lock-writing resync dxkit can name, so the full `composer update`
+      // may also refresh unrelated packages within their declared
+      // constraints. The re-audit and the run guardrail check the whole
+      // tree, so nothing rides in unchecked; the diff is just wider.
+      notes: [
+        'the composer lock resync (composer update) may also refresh unrelated packages in ' +
+          'composer.lock within their declared constraints; the re-audit and the guardrail ' +
+          'check the whole tree',
+      ],
     };
   },
   execution: () => PHP_REMEDIATION_EXECUTION,

--- a/src/languages/php-remediation.ts
+++ b/src/languages/php-remediation.ts
@@ -1,0 +1,139 @@
+/**
+ * The php ecosystem's remediation capabilities (the pack's `remediation`,
+ * Rule 6, the node-remediation.ts sibling): every composer fact the
+ * recipe executors consume through the capability seam.
+ *
+ * Doctrine notes, kept beside the declarations they explain:
+ *   - Composer has no override table; its documented way to constrain a
+ *     transitive dependency is REQUIRING IT DIRECTLY with the constraint.
+ *     The pin therefore lands as an exact-version `require` entry (the
+ *     explicit-entry pin, the Gemfile/poetry sibling). The alternative
+ *     `conflict` + `require` pattern was deliberately NOT chosen: a
+ *     `conflict` entry only forbids the vulnerable version, it cannot
+ *     force a resolution on its own and fails opaquely when nothing else
+ *     satisfies the graph, while a direct require both constrains and
+ *     resolves, and reverts by removing one entry. A package already in
+ *     `require`/`require-dev` refuses (the honest fix is upgrading the
+ *     declared dependency, the dep-bump lane's job).
+ *   - `declareDependency` is a REASONED EXEMPTION: the php resolution
+ *     check reports unresolved NAMESPACE roots (`Monolog\`), and a
+ *     namespace does not identify a Packagist package (`Symfony\Component
+ *     \Console` is symfony/console); deriving vendor/package from a
+ *     namespace mechanically would be a guess, and the bias is to refuse.
+ *   - `lintFix` is a REASONED EXEMPTION: the pack's lint gate is phpcs,
+ *     and its fixer phpcbf reports what it FIXED rather than what
+ *     remains, so one fix run cannot also verify the order's findings are
+ *     gone (the seam's one-run fix-and-verify contract); a different
+ *     fixer (pint, php-cs-fixer) answers different rules than the gate's
+ *     sniffs and would read as net-new leftovers.
+ */
+import { serializePreservingJson } from '../files';
+import type { ExecutionRequirement } from '../execution';
+import type {
+  ManifestTextEdit,
+  PinPlanResult,
+  PinTransitiveProvider,
+  RemediationSupport,
+} from './capabilities/remediation';
+
+/** Remediation commands run on the ambient php toolchain (composer rides
+ *  the php CLI), any host, no build. */
+const PHP_REMEDIATION_EXECUTION: ExecutionRequirement = {
+  hosts: ['any'],
+  toolchains: ['php'],
+  needsBuild: false,
+  buildTarget: 'none',
+  weight: 'cheap',
+};
+
+/** Composer's documented `vendor/package` name shape (lowercase, dots,
+ *  dashes, underscores; exactly one slash). The Rule 11 rail for the pin's
+ *  package token before it lands in manifest text. */
+const COMPOSER_PACKAGE_NAME = /^[a-z0-9]([_.-]?[a-z0-9]+)*\/[a-z0-9](([_.]|-{1,2})?[a-z0-9]+)*$/;
+
+export function isValidComposerPackageName(name: string): boolean {
+  return name.length > 0 && name.length <= 214 && COMPOSER_PACKAGE_NAME.test(name);
+}
+
+/** A composer version shape (digits-led, optional stability suffix). */
+const COMPOSER_VERSION = /^[0-9][0-9A-Za-z.+-]*$/;
+
+/** The exact-version `require` entry as a PURE text transform, preserving
+ *  the manifest's own indentation and trailing newline (the one
+ *  style-preserving JSON writer). Refuses a direct dependency. */
+function composerRequireTransform(pkg: string, version: string): ManifestTextEdit['transform'] {
+  return (text) => {
+    let manifest: Record<string, unknown>;
+    try {
+      const parsed: unknown = JSON.parse(text);
+      if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        return { refused: 'the composer.json here is not a JSON object, so it cannot be edited' };
+      }
+      manifest = parsed as Record<string, unknown>;
+    } catch {
+      return { refused: 'the composer.json here does not parse as JSON, so it cannot be edited' };
+    }
+    for (const section of ['require', 'require-dev'] as const) {
+      const deps = manifest[section];
+      if (deps && typeof deps === 'object' && pkg in (deps as Record<string, unknown>)) {
+        return {
+          refused:
+            `'${pkg}' is a direct ${section} dependency of this manifest; the honest fix is ` +
+            'upgrading the declared dependency (the dep-bump lane), not pinning it again',
+        };
+      }
+    }
+    const require =
+      manifest.require && typeof manifest.require === 'object'
+        ? (manifest.require as Record<string, unknown>)
+        : {};
+    require[pkg] = version;
+    manifest.require = require;
+    return { text: serializePreservingJson(text, manifest) };
+  };
+}
+
+const phpPinTransitive: PinTransitiveProvider = {
+  manifestFiles: ['composer.json'],
+  osvEcosystem: 'Packagist',
+  plan(ctx): PinPlanResult {
+    // Rule 11: both tokens land in manifest text verbatim.
+    if (!isValidComposerPackageName(ctx.pkg) || !COMPOSER_VERSION.test(ctx.version)) {
+      return {
+        kind: 'refused',
+        reason:
+          `'${ctx.pkg}@${ctx.version}' is not a composer package name + version shape ` +
+          'dxkit will write into a manifest',
+      };
+    }
+    const at = ctx.rootDir ? `${ctx.rootDir}/` : '';
+    return {
+      kind: 'plan',
+      edit: { file: 'composer.json', transform: composerRequireTransform(ctx.pkg, ctx.version) },
+      revert: `remove the "require" entry for '${ctx.pkg}' from ${at}composer.json and re-run the lock resync`,
+    };
+  },
+  execution: () => PHP_REMEDIATION_EXECUTION,
+};
+
+/** The php pack's remediation declarations: resync + pin are capabilities
+ *  (both ride composer through the install strategy); declare + lintFix
+ *  are reasoned exemptions (the doctrine block above says why). */
+export const phpRemediation: RemediationSupport = {
+  resyncLockfile: { kind: 'capability', provider: { manifestFiles: ['composer.json'] } },
+  pinTransitive: { kind: 'capability', provider: phpPinTransitive },
+  declareDependency: {
+    kind: 'exemption',
+    reason:
+      'an unresolved php import names a namespace, and a namespace does not identify a ' +
+      'Packagist package (the vendor/package name cannot be derived from it mechanically); ' +
+      'these orders stay on the agent tier',
+  },
+  lintFix: {
+    kind: 'exemption',
+    reason:
+      'phpcbf, the phpcs fixer, reports what it fixed rather than what remains, so a single ' +
+      "fix run cannot also verify the order's findings are gone; these orders stay on the " +
+      'agent tier',
+  },
+};

--- a/src/languages/php.ts
+++ b/src/languages/php.ts
@@ -1,5 +1,5 @@
 import { NO_TREE_INVARIANTS } from './capabilities/tree-invariants';
-import { plannedRemediationSupport } from './capabilities/remediation';
+import { phpRemediation } from './php-remediation';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -24,8 +24,11 @@ import type {
   CorrectnessCommand,
   CorrectnessContext,
   CorrectnessProvider,
+  LockfileCheck,
   ResolutionCheckResult,
 } from './capabilities/correctness';
+import { lockfileCheckFromStrategy } from './capabilities/correctness';
+import { resolveTolerances } from '../install/tolerances';
 import type {
   CoverageResult,
   DepVulnGatherOutcome,
@@ -633,6 +636,15 @@ export function phpResolutionCheck(ctx: CorrectnessContext): ResolutionCheckResu
 const phpCorrectnessProvider: CorrectnessProvider = {
   resolutionCheck: phpResolutionCheck,
 
+  // The lockfile-sync check (4.4.7): composer's own offline validate,
+  // derived from the strategy's declared sync check through the ONE
+  // derivation, so the check and the install read one declaration.
+  lockfileCheck(ctx: CorrectnessContext): LockfileCheck | null {
+    const strategy = phpInstallStrategy.strategy(ctx.cwd);
+    if (strategy === null || strategy.lockfile === null) return null;
+    return lockfileCheckFromStrategy(strategy, ctx.tolerances ?? resolveTolerances(ctx.cwd));
+  },
+
   execution: () => PHP_CLI_EXECUTION,
 
   syntaxCheck(ctx: CorrectnessContext): CorrectnessCommand | null {
@@ -682,7 +694,25 @@ const phpInstallStrategy = declareInstallStrategy(
       strategy: {
         manager: 'composer',
         lockfile: 'composer.lock',
-        modes: { frozen: { primary: { bin: 'composer', args: ['install'] }, fallbacks: [] } },
+        modes: {
+          frozen: { primary: { bin: 'composer', args: ['install'] }, fallbacks: [] },
+          // `composer update` is composer's own lock-writing resync (its
+          // stale-lock error names it as the remedy): re-resolve within
+          // the manifest's constraints, rewrite composer.lock, install.
+          resync: { primary: { bin: 'composer', args: ['update'] }, fallbacks: [] },
+        },
+        // `composer validate` checks the lock against composer.json by
+        // default and exits non-zero on a stale lock (verified: exit 2);
+        // --no-check-all / --no-check-publish keep unrelated manifest
+        // warnings from failing the sync question. Offline, non-installing.
+        syncCheck: {
+          kind: 'command',
+          command: {
+            bin: 'composer',
+            args: ['validate', '--no-check-all', '--no-check-publish'],
+          },
+          tolerates: [],
+        },
         execution: {
           hosts: ['any'],
           toolchains: ['php'],
@@ -772,7 +802,7 @@ export const php: LanguageSupport = {
   callGraphReliability: 'partial',
 
   treeInvariants: NO_TREE_INVARIANTS,
-  remediation: plannedRemediationSupport('php'),
+  remediation: phpRemediation,
   correctness: phpCorrectnessProvider,
   lintGate: phpLintGateProvider,
 

--- a/src/languages/php.ts
+++ b/src/languages/php.ts
@@ -699,6 +699,10 @@ const phpInstallStrategy = declareInstallStrategy(
           // `composer update` is composer's own lock-writing resync (its
           // stale-lock error names it as the remedy): re-resolve within
           // the manifest's constraints, rewrite composer.lock, install.
+          // DELIBERATE churn: composer has no scoped resync dxkit can
+          // name, so unrelated packages may refresh within their declared
+          // constraints; the pin capability discloses this on the ledger
+          // and the re-audit + guardrail check the whole tree.
           resync: { primary: { bin: 'composer', args: ['update'] }, fallbacks: [] },
         },
         // `composer validate` checks the lock against composer.json by

--- a/src/languages/python-dist-names.ts
+++ b/src/languages/python-dist-names.ts
@@ -9,38 +9,56 @@
  * consumers, per CLAUDE.md Rule 2.30.
  */
 
-/** Known import-name → distribution-name divergences. Multiple candidates
- *  mean the import is served by genuinely DIFFERENT distributions (or by
- *  spelling variants that fold together under PEP 503). Curated, biased
- *  small: an absent entry means "the import name IS the distribution
- *  name", the ecosystem's dominant convention. */
+/**
+ * Known import-name → distribution-name divergences. An entry is an
+ * INSTALL DECISION, not just an exemption: a single candidate means "this
+ * is THE distribution declaring the import installs" (the declare recipe
+ * acts on it), so a single candidate is declared only where the mapping is
+ * unambiguous in practice. Multiple candidates mean the import is served
+ * by genuinely DIFFERENT distributions; declare refuses those to the agent
+ * tier, and the resolution check exempts a declared ANY of them. All names
+ * compare under PEP 503 normalization, so spelling variants of one
+ * distribution need no duplicate entries. Curated, biased small: an
+ * absent entry means "the import name IS the distribution name", the
+ * ecosystem's dominant convention.
+ */
 export const PY_MODULE_DIST_ALIASES: Readonly<Record<string, readonly string[]>> = {
   yaml: ['pyyaml'],
   PIL: ['pillow'],
-  sklearn: ['scikit-learn', 'scikit_learn'],
+  sklearn: ['scikit-learn'],
   bs4: ['beautifulsoup4'],
-  cv2: ['opencv-python', 'opencv-python-headless', 'opencv_python'],
-  dotenv: ['python-dotenv', 'python_dotenv'],
-  dateutil: ['python-dateutil', 'python_dateutil'],
-  jose: ['python-jose', 'python_jose'],
+  cv2: ['opencv-python', 'opencv-python-headless'],
+  dotenv: ['python-dotenv'],
+  dateutil: ['python-dateutil'],
+  jose: ['python-jose'],
+  // A dist literally named "jwt" exists, but pyjwt is the overwhelmingly
+  // dominant provider of the `jwt` module; installing the niche homonym
+  // would be the wrong call far more often than this mapping is.
   jwt: ['pyjwt'],
+  // pycryptodome is the maintained drop-in, but pycrypto code still exists
+  // in the wild: two real distributions, so declare refuses.
   Crypto: ['pycryptodome', 'pycrypto'],
-  magic: ['python-magic', 'python_magic'],
+  magic: ['python-magic'],
   git: ['gitpython'],
   github: ['pygithub'],
-  docx: ['python-docx', 'python_docx'],
-  pptx: ['python-pptx', 'python_pptx'],
-  slugify: ['python-slugify', 'python_slugify'],
+  docx: ['python-docx'],
+  pptx: ['python-pptx'],
+  slugify: ['python-slugify'],
   MySQLdb: ['mysqlclient'],
-  psycopg2: ['psycopg2-binary', 'psycopg2_binary'],
+  // `import psycopg2` is genuinely served by two distinct distributions
+  // (the source dist and the -binary wheels), and which one a deployment
+  // wants is a real decision: declare refuses, the checker exempts both.
+  psycopg2: ['psycopg2', 'psycopg2-binary'],
   attr: ['attrs'],
   serial: ['pyserial'],
   usb: ['pyusb'],
   OpenSSL: ['pyopenssl'],
   wx: ['wxpython'],
   fitz: ['pymupdf'],
-  kafka: ['kafka-python', 'kafka_python'],
-  snowflake: ['snowflake-connector-python', 'snowflake_connector_python'],
+  kafka: ['kafka-python'],
+  // The connector and snowpark both own the `snowflake` namespace package:
+  // two real distributions, so declare refuses and either exempts.
+  snowflake: ['snowflake-connector-python', 'snowflake-snowpark-python'],
   google: ['protobuf', 'google-api-python-client', 'google-cloud-storage'],
 };
 

--- a/src/languages/python-dist-names.ts
+++ b/src/languages/python-dist-names.ts
@@ -1,0 +1,76 @@
+/**
+ * How a python IMPORT name relates to a PyPI DISTRIBUTION name: the ONE
+ * home of the curated alias table (the `yaml` → `pyyaml`, `PIL` → `pillow`
+ * class, where the module a file imports is not the distribution pip
+ * installs) plus the PEP 503 name normalization. Consumed by BOTH the
+ * import-resolution check (does a declared distribution answer this
+ * import?) and the declare-dependency remediation capability (which
+ * distribution would declaring this import install?): one table, two
+ * consumers, per CLAUDE.md Rule 2.30.
+ */
+
+/** Known import-name → distribution-name divergences. Multiple candidates
+ *  mean the import is served by genuinely DIFFERENT distributions (or by
+ *  spelling variants that fold together under PEP 503). Curated, biased
+ *  small: an absent entry means "the import name IS the distribution
+ *  name", the ecosystem's dominant convention. */
+export const PY_MODULE_DIST_ALIASES: Readonly<Record<string, readonly string[]>> = {
+  yaml: ['pyyaml'],
+  PIL: ['pillow'],
+  sklearn: ['scikit-learn', 'scikit_learn'],
+  bs4: ['beautifulsoup4'],
+  cv2: ['opencv-python', 'opencv-python-headless', 'opencv_python'],
+  dotenv: ['python-dotenv', 'python_dotenv'],
+  dateutil: ['python-dateutil', 'python_dateutil'],
+  jose: ['python-jose', 'python_jose'],
+  jwt: ['pyjwt'],
+  Crypto: ['pycryptodome', 'pycrypto'],
+  magic: ['python-magic', 'python_magic'],
+  git: ['gitpython'],
+  github: ['pygithub'],
+  docx: ['python-docx', 'python_docx'],
+  pptx: ['python-pptx', 'python_pptx'],
+  slugify: ['python-slugify', 'python_slugify'],
+  MySQLdb: ['mysqlclient'],
+  psycopg2: ['psycopg2-binary', 'psycopg2_binary'],
+  attr: ['attrs'],
+  serial: ['pyserial'],
+  usb: ['pyusb'],
+  OpenSSL: ['pyopenssl'],
+  wx: ['wxpython'],
+  fitz: ['pymupdf'],
+  kafka: ['kafka-python', 'kafka_python'],
+  snowflake: ['snowflake-connector-python', 'snowflake_connector_python'],
+  google: ['protobuf', 'google-api-python-client', 'google-cloud-storage'],
+};
+
+/** PEP 503 name normalization: distribution names compare case-insensitively
+ *  with runs of `-`, `_`, `.` folded to one `-`. */
+export function normalizePyDistName(name: string): string {
+  return name.toLowerCase().replace(/[-_.]+/g, '-');
+}
+
+/** A top-level python module name (the shape the resolution check reports
+ *  as an unresolved specifier). Doubles as the Rule 11 argument-injection
+ *  rail for the declare capability: no leading dash, no whitespace, no URL
+ *  can pass this. */
+export function isPyModuleName(specifier: string): boolean {
+  return specifier.length > 0 && specifier.length <= 128 && /^[A-Za-z_]\w*$/.test(specifier);
+}
+
+/**
+ * The ONE distribution declaring this import would install, PEP-503
+ * normalized, or null when dxkit cannot name it: a malformed specifier, or
+ * an alias whose candidates are genuinely different distributions (`cv2`,
+ * `google`): those need judgment, so they stay on the agent tier
+ * (false-negative bias: never guess which package to install).
+ */
+export function pyDistForImport(specifier: string): string | null {
+  if (!isPyModuleName(specifier)) return null;
+  const aliases = PY_MODULE_DIST_ALIASES[specifier];
+  if (aliases !== undefined) {
+    const normalized = [...new Set(aliases.map(normalizePyDistName))];
+    return normalized.length === 1 ? normalized[0] : null;
+  }
+  return normalizePyDistName(specifier);
+}

--- a/src/languages/python-install.ts
+++ b/src/languages/python-install.ts
@@ -72,6 +72,16 @@ export const pythonInstallStrategy = declareInstallStrategy(
           kind: 'command',
           command: { bin: 'poetry', args: ['check', '--lock'] },
           tolerates: [],
+          // poetry has no lock-only check: `check --lock` validates the
+          // whole pyproject too (the php strategy scopes composer validate
+          // with --no-check-all; poetry offers no such flag). A failure
+          // that never mentions the lock is a MANIFEST error, disclosed as
+          // such so it is not read, or remediated, as lockfile drift.
+          classifyFailure: (output) =>
+            /poetry\.lock|lock file|poetry lock/i.test(output)
+              ? null
+              : 'manifest-validation: pyproject.toml itself failed poetry check (no lockfile ' +
+                'drift is reported); fix the manifest error above rather than re-locking.',
         },
         execution: PYTHON_INSTALL_EXECUTION,
       },

--- a/src/languages/python-install.ts
+++ b/src/languages/python-install.ts
@@ -1,0 +1,129 @@
+/**
+ * How a python root installs (CLAUDE.md Rule 6), split out of `python.ts`
+ * (the node-install.ts precedent) so the remediation capabilities can read
+ * the SAME strategy without a module cycle: one variant per dependency
+ * artifact, in preference order.
+ *
+ * Doctrine notes, kept beside the declarations they explain:
+ *   - The frozen forms are the ones that REFUSE a stale lockfile
+ *     (`uv sync --locked`, `pipenv install --deploy`, and `poetry install`,
+ *     which aborts when pyproject moved ahead of poetry.lock).
+ *   - uv and pipenv resync through the ONE command that both rewrites the
+ *     lockfile and installs. poetry's resync is `poetry lock --no-update`
+ *     (rewrite only what pyproject requires, poetry 1.x spelling) with the
+ *     plain `poetry lock` as the intrinsic unsupported-flag fallback:
+ *     poetry 2 removed `--no-update` because its behavior became the
+ *     default, so the rejected flag routes to the plain spelling: the
+ *     yarn `--frozen-lockfile`/`--immutable` dance, one ladder, disclosed.
+ *   - Lockfile-sync checks are the non-installing dry-runs each manager
+ *     actually has: `poetry check --lock` (pyproject ↔ poetry.lock
+ *     consistency), `uv lock --check` (assert the lockfile would not
+ *     change), `pipenv verify` (the Pipfile hash recorded in
+ *     Pipfile.lock). Plain requirements roots have no lockfile, so they
+ *     declare neither a resync nor a sync check.
+ *   - No ecosystem tolerance exists here: python resolvers have no
+ *     peer-check analogue, so no repo-authorized fallbacks are declared.
+ */
+import type { ExecutionRequirement } from '../execution';
+import { declareInstallStrategy } from './capabilities/install-strategy';
+
+/** Installs run on the ambient python toolchain, any host, no build. */
+export const PYTHON_INSTALL_EXECUTION: ExecutionRequirement = {
+  hosts: ['any'],
+  toolchains: ['python'],
+  needsBuild: false,
+  buildTarget: 'none',
+  weight: 'cheap',
+};
+
+export const pythonInstallStrategy = declareInstallStrategy(
+  [
+    {
+      when: ['poetry.lock'],
+      strategy: {
+        manager: 'poetry',
+        lockfile: 'poetry.lock',
+        modes: {
+          frozen: { primary: { bin: 'poetry', args: ['install'] }, fallbacks: [] },
+          resync: {
+            primary: { bin: 'poetry', args: ['lock', '--no-update'] },
+            fallbacks: [
+              {
+                command: { bin: 'poetry', args: ['lock'] },
+                when: 'unsupported-flag',
+                // Only the flag REJECTION routes here (cleo's "does not
+                // exist" / click's "no such option" naming --no-update); a
+                // real resolution failure never matches.
+                matches: (output) =>
+                  /no-update/.test(output) &&
+                  /no such option|does not exist|unknown option|unexpected argument/i.test(output),
+                disclosure:
+                  'poetry 2 removed --no-update (its behavior became the default); ' +
+                  'retried with the plain lock',
+                // The rendered chain retries blanket, so the guard confines
+                // it to poetry >= 2, where the plain lock IS the minimal
+                // resync; on poetry 1.x it would re-resolve everything.
+                shellGuard: 'poetry --version 2>/dev/null | grep -qE "version [2-9]"',
+              },
+            ],
+          },
+        },
+        syncCheck: {
+          kind: 'command',
+          command: { bin: 'poetry', args: ['check', '--lock'] },
+          tolerates: [],
+        },
+        execution: PYTHON_INSTALL_EXECUTION,
+      },
+    },
+    {
+      when: ['uv.lock'],
+      strategy: {
+        manager: 'uv',
+        lockfile: 'uv.lock',
+        modes: {
+          frozen: { primary: { bin: 'uv', args: ['sync', '--locked'] }, fallbacks: [] },
+          resync: { primary: { bin: 'uv', args: ['sync'] }, fallbacks: [] },
+        },
+        syncCheck: {
+          kind: 'command',
+          command: { bin: 'uv', args: ['lock', '--check'] },
+          tolerates: [],
+        },
+        execution: PYTHON_INSTALL_EXECUTION,
+      },
+    },
+    {
+      when: ['Pipfile.lock'],
+      strategy: {
+        manager: 'pipenv',
+        lockfile: 'Pipfile.lock',
+        modes: {
+          frozen: { primary: { bin: 'pipenv', args: ['install', '--deploy'] }, fallbacks: [] },
+          resync: { primary: { bin: 'pipenv', args: ['install'] }, fallbacks: [] },
+        },
+        syncCheck: {
+          kind: 'command',
+          command: { bin: 'pipenv', args: ['verify'] },
+          tolerates: [],
+        },
+        execution: PYTHON_INSTALL_EXECUTION,
+      },
+    },
+    {
+      when: ['requirements.txt'],
+      strategy: {
+        manager: 'pip',
+        lockfile: null,
+        modes: {
+          frozen: {
+            primary: { bin: 'pip', args: ['install', '-r', 'requirements.txt'] },
+            fallbacks: [],
+          },
+        },
+        execution: PYTHON_INSTALL_EXECUTION,
+      },
+    },
+  ],
+  { ciDependencyInstall: false },
+);

--- a/src/languages/python-remediation.ts
+++ b/src/languages/python-remediation.ts
@@ -1,0 +1,360 @@
+/**
+ * The python ecosystem's remediation capabilities (the pack's
+ * `remediation`, Rule 6, the node-remediation.ts sibling): every
+ * poetry/uv/pipenv/pip fact the recipe executors consume through the
+ * capability seam.
+ *
+ * Doctrine notes, kept beside the declarations they explain:
+ *   - Which manager owns a root is the SAME question the install strategy
+ *     answers, so the pin plan and the install command both dispatch
+ *     through `pythonInstallStrategy.strategy(root)` (Rule 2: never a
+ *     second lockfile-sniffing table).
+ *   - The pin mechanism differs per manager. uv has a real override
+ *     surface (`[tool.uv] override-dependencies`), so the pin lands there.
+ *     poetry and pipenv have NO override mechanism; their community-
+ *     standard fix is the EXPLICIT-ENTRY pin: declare the transitive
+ *     directly at the exact patched version so the resolver must take it,
+ *     and the revert prose says exactly which entry to remove. A plain
+ *     requirements root has no lockfile to verify a pin against, so it is
+ *     a declared refusal (the constraints-file mechanism stays on the
+ *     agent tier rather than shipping unverifiable).
+ *   - A DIRECT dependency refuses the pin everywhere: the honest fix is
+ *     upgrading the declared dependency (the dep-bump lane's job). The
+ *     direct-dependency read here is a TARGETED parse of the dependency
+ *     tables, deliberately separate from `pyDeclaredDeps` in python.ts:
+ *     that helper over-captures on purpose (its names only ever EXEMPT an
+ *     unresolved import), which would refuse pins on any stray quoted
+ *     token. Both biases point the same safe direction for their consumer.
+ *   - Declaring an import installs a DISTRIBUTION, and python import names
+ *     are not distribution names (`yaml` is pyyaml; `cv2` is one of three
+ *     packages). The ONE import→distribution mapping
+ *     (`python-dist-names.ts`, shared with the resolution check) is the
+ *     rail: an import dxkit cannot map to exactly one distribution never
+ *     reaches a package-manager argv (false-negative bias: installing the
+ *     wrong same-named package is the typosquat class).
+ *   - The version probe is `pip index versions`, which resolves against
+ *     the repo's own pip configuration; pip ships with the python
+ *     toolchain dxkit already requires, so the probe holds whichever
+ *     manager owns the root.
+ */
+import { join } from 'path';
+import type {
+  DeclareDependencyProvider,
+  ManifestTextEdit,
+  PinPlanResult,
+  PinTransitiveProvider,
+  RemediationSupport,
+} from './capabilities/remediation';
+import { pyDistForImport } from './python-dist-names';
+import { pythonInstallStrategy, PYTHON_INSTALL_EXECUTION } from './python-install';
+
+// ── shared rails ───────────────────────────────────────────────────────────
+
+/** A PyPI distribution name shape (PEP 508), the Rule 11 rail for a pin's
+ *  package argument before it lands in manifest text. */
+const PY_DIST_NAME = /^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$/;
+
+/** A PEP 440 version shape (epoch, pre/post/dev, local segments). */
+const PY_VERSION = /^[0-9][0-9A-Za-z.+!-]*$/;
+
+function directDepRefusal(pkg: string): string {
+  return (
+    `'${pkg}' is a direct dependency of this manifest; the honest fix is ` +
+    'upgrading the declared dependency (the dep-bump lane), not pinning it'
+  );
+}
+
+// ── TOML text surgery (line-level, style-preserving, refusal-biased) ──────
+
+/** The `[name]` table in `lines`: header index and exclusive body end. */
+function findTomlTable(
+  lines: readonly string[],
+  name: string,
+): { header: number; end: number } | null {
+  const headerRe = new RegExp(`^\\s*\\[${name.replace(/\./g, '\\.')}\\]\\s*(#.*)?$`);
+  for (let i = 0; i < lines.length; i++) {
+    if (!headerRe.test(lines[i])) continue;
+    let end = lines.length;
+    for (let j = i + 1; j < lines.length; j++) {
+      if (/^\s*\[/.test(lines[j])) {
+        end = j;
+        break;
+      }
+    }
+    return { header: i, end };
+  }
+  return null;
+}
+
+/** Every table header name in the document. */
+function tomlTableNames(lines: readonly string[]): string[] {
+  const out: string[] = [];
+  for (const line of lines) {
+    const m = line.match(/^\s*\[\s*([^\]]+?)\s*\]\s*(#.*)?$/);
+    if (m) out.push(m[1]);
+  }
+  return out;
+}
+
+/** Key names declared in one table's body (`name = ...` lines, quoted or
+ *  bare), PEP-503 normalized for comparison. */
+function tableKeyNames(lines: readonly string[], table: { header: number; end: number }): string[] {
+  const out: string[] = [];
+  for (let i = table.header + 1; i < table.end; i++) {
+    const m = lines[i].match(/^\s*(?:"([^"]+)"|'([^']+)'|([A-Za-z0-9._-]+))\s*=/);
+    if (m) out.push(m[1] ?? m[2] ?? m[3]);
+  }
+  return out;
+}
+
+/** The quoted requirement strings of every `<key> = [ ... ]` array in one
+ *  table's body (bracket-balanced across lines), as leading PEP 508 names. */
+function tableArrayRequirementNames(
+  lines: readonly string[],
+  table: { header: number; end: number },
+): string[] {
+  const out: string[] = [];
+  let openBrackets = 0;
+  for (let i = table.header + 1; i < table.end; i++) {
+    const line = lines[i];
+    const opensArray =
+      openBrackets === 0 && /^\s*(?:"[^"]+"|'[^']+'|[A-Za-z0-9._-]+)\s*=\s*\[/.test(line);
+    if (opensArray || openBrackets > 0) {
+      for (const m of line.matchAll(/["']([^"']+)["']/g)) {
+        const name = m[1].match(/^\s*([A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?)/);
+        if (name) out.push(name[1]);
+      }
+      openBrackets += (line.match(/\[/g) ?? []).length - (line.match(/\]/g) ?? []).length;
+      if (openBrackets < 0) openBrackets = 0;
+    }
+  }
+  return out;
+}
+
+const norm = (n: string): string => n.toLowerCase().replace(/[-_.]+/g, '-');
+
+/** Is `pkg` a direct dependency under PEP 621 (`[project]` dependencies +
+ *  `[project.optional-dependencies]` groups)? */
+function directInPep621(lines: readonly string[], pkg: string): boolean {
+  const target = norm(pkg);
+  for (const name of ['project', 'project.optional-dependencies']) {
+    const table = findTomlTable(lines, name);
+    if (table && tableArrayRequirementNames(lines, table).some((n) => norm(n) === target)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Is `pkg` declared as a key in any table whose name matches `re`? */
+function directInKeyedTables(lines: readonly string[], re: RegExp, pkg: string): boolean {
+  const target = norm(pkg);
+  return tomlTableNames(lines).some((name) => {
+    if (!re.test(name)) return false;
+    const table = findTomlTable(lines, name);
+    return table !== null && tableKeyNames(lines, table).some((n) => norm(n) === target);
+  });
+}
+
+/** Every transform starts here: a manifest with no table header at all is
+ *  not TOML dxkit can edit (garbage, an empty file, JSON). */
+function notToml(text: string, what: string): string | null {
+  return /^\s*\[[^\]]*\]/m.test(text)
+    ? null
+    : `this ${what} does not parse as a TOML manifest, so it cannot be edited`;
+}
+
+// ── the three pin transforms ───────────────────────────────────────────────
+
+/** uv: `[tool.uv] override-dependencies = ["pkg==version"]`, the
+ *  ecosystem's real override surface. Refuses a direct dependency and an
+ *  ALREADY-present override list (merging into one needs judgment). */
+function uvOverrideTransform(pkg: string, version: string): ManifestTextEdit['transform'] {
+  return (text) => {
+    const guard = notToml(text, 'pyproject.toml');
+    if (guard) return { refused: guard };
+    if (directInPep621(text.split('\n'), pkg)) return { refused: directDepRefusal(pkg) };
+    if (/override-dependencies/.test(text)) {
+      return {
+        refused:
+          'this pyproject.toml already declares override-dependencies; merging into an ' +
+          'existing override list needs judgment, so this pin stays on the agent tier',
+      };
+    }
+    const entry = `override-dependencies = ["${pkg}==${version}"]`;
+    const lines = text.split('\n');
+    const table = findTomlTable(lines, 'tool.uv');
+    if (table) {
+      lines.splice(table.header + 1, 0, entry);
+      return { text: lines.join('\n') };
+    }
+    const base = text.endsWith('\n') ? text : `${text}\n`;
+    return { text: `${base}\n[tool.uv]\n${entry}\n` };
+  };
+}
+
+/** poetry: the explicit-entry pin into `[tool.poetry.dependencies]` (a bare
+ *  version string is an EXACT requirement in poetry). Refuses a direct
+ *  dependency in any poetry dependency table or under PEP 621, and a
+ *  pyproject with no `[tool.poetry.dependencies]` table (a PEP 621 poetry
+ *  layout, where the entry should land needs judgment). */
+function poetryPinTransform(pkg: string, version: string): ManifestTextEdit['transform'] {
+  const poetryDepTables = /^tool\.poetry(\.group\.[^.]+)?\.(dev-)?dependencies$/;
+  return (text) => {
+    const guard = notToml(text, 'pyproject.toml');
+    if (guard) return { refused: guard };
+    const lines = text.split('\n');
+    if (directInPep621(lines, pkg) || directInKeyedTables(lines, poetryDepTables, pkg)) {
+      return { refused: directDepRefusal(pkg) };
+    }
+    const table = findTomlTable(lines, 'tool.poetry.dependencies');
+    if (table === null) {
+      return {
+        refused:
+          'this pyproject.toml declares no [tool.poetry.dependencies] table, so the ' +
+          'explicit-entry pin has nowhere to land; this pin stays on the agent tier',
+      };
+    }
+    lines.splice(table.header + 1, 0, `${pkg} = "${version}"`);
+    return { text: lines.join('\n') };
+  };
+}
+
+/** pipenv: the explicit-entry pin into `[packages]` (`pkg = "==version"`).
+ *  Refuses a direct dependency in `[packages]` / `[dev-packages]` and a
+ *  Pipfile with no `[packages]` table. */
+function pipfilePinTransform(pkg: string, version: string): ManifestTextEdit['transform'] {
+  return (text) => {
+    const guard = notToml(text, 'Pipfile');
+    if (guard) return { refused: guard };
+    const lines = text.split('\n');
+    if (directInKeyedTables(lines, /^(dev-)?packages$/, pkg)) {
+      return { refused: directDepRefusal(pkg) };
+    }
+    const table = findTomlTable(lines, 'packages');
+    if (table === null) {
+      return {
+        refused:
+          'this Pipfile declares no [packages] table, so the explicit-entry pin has ' +
+          'nowhere to land; this pin stays on the agent tier',
+      };
+    }
+    lines.splice(table.header + 1, 0, `${pkg} = "==${version}"`);
+    return { text: lines.join('\n') };
+  };
+}
+
+// ── the providers ──────────────────────────────────────────────────────────
+
+const pythonPinTransitive: PinTransitiveProvider = {
+  manifestFiles: ['pyproject.toml', 'Pipfile'],
+  osvEcosystem: 'PyPI',
+  plan(ctx): PinPlanResult {
+    // Rule 11: both tokens land in manifest text verbatim; anything outside
+    // the ecosystem's own name/version shapes is refused before any edit.
+    if (!PY_DIST_NAME.test(ctx.pkg) || !PY_VERSION.test(ctx.version)) {
+      return {
+        kind: 'refused',
+        reason: `'${ctx.pkg}@${ctx.version}' is not a PyPI package name + PEP 440 version shape dxkit will write into a manifest`,
+      };
+    }
+    const strategy = pythonInstallStrategy.strategy(join(ctx.cwd, ctx.rootDir));
+    if (strategy === null) {
+      return {
+        kind: 'refused',
+        reason:
+          'no python dependency artifact at this root selects a package manager to pin through',
+      };
+    }
+    const at = ctx.rootDir ? `${ctx.rootDir}/` : '';
+    switch (strategy.manager) {
+      case 'uv':
+        return {
+          kind: 'plan',
+          edit: { file: 'pyproject.toml', transform: uvOverrideTransform(ctx.pkg, ctx.version) },
+          revert:
+            `remove the [tool.uv] override-dependencies entry for '${ctx.pkg}' from ` +
+            `${at}pyproject.toml and re-run the lock resync`,
+        };
+      case 'poetry':
+        return {
+          kind: 'plan',
+          edit: { file: 'pyproject.toml', transform: poetryPinTransform(ctx.pkg, ctx.version) },
+          revert:
+            `remove the '${ctx.pkg}' entry from [tool.poetry.dependencies] in ` +
+            `${at}pyproject.toml and re-run the lock resync`,
+        };
+      case 'pipenv':
+        return {
+          kind: 'plan',
+          edit: { file: 'Pipfile', transform: pipfilePinTransform(ctx.pkg, ctx.version) },
+          revert: `remove the '${ctx.pkg}' entry from [packages] in ${at}Pipfile and re-run the lock resync`,
+        };
+      default:
+        return {
+          kind: 'refused',
+          reason:
+            'a plain requirements root has no lockfile to verify a pin against; the pip ' +
+            'constraints-file mechanism stays on the agent tier',
+        };
+    }
+  },
+  execution: () => PYTHON_INSTALL_EXECUTION,
+};
+
+const pythonDeclareDependency: DeclareDependencyProvider = {
+  manifestFiles: ['pyproject.toml', 'Pipfile', 'requirements.txt'],
+  osvEcosystem: 'PyPI',
+  packageNameLabel: 'python import dxkit can map to one PyPI distribution',
+  // The rail folds the injection shape AND the mapping question into one
+  // answer: an import that maps to no single distribution (malformed, or an
+  // ambiguous alias like cv2/google) never reaches an argv.
+  validSpecifier: (specifier) => pyDistForImport(specifier) !== null,
+  versionProbe: (ctx) => ({
+    bin: 'pip',
+    args: ['index', 'versions', pyDistForImport(ctx.specifier) ?? ctx.specifier],
+  }),
+  parseProbeOutput(output) {
+    // `pip index versions requests` → `requests (2.32.5)` then an
+    // `Available versions:` list; either names the latest first.
+    for (const line of output.split('\n')) {
+      const m = line.match(/^\s*[A-Za-z0-9._-]+\s+\((\d[^)\s,]*)\s*\)\s*$/);
+      if (m) return m[1];
+    }
+    const avail = output.match(/Available versions:\s*(\d[^\s,]*)/);
+    return avail ? avail[1] : null;
+  },
+  installCommand(ctx) {
+    const dist = pyDistForImport(ctx.specifier) ?? ctx.specifier;
+    const spec = `${dist}==${ctx.version}`;
+    // The manager owning this root, from the same strategy pick every other
+    // consumer reads (a lockfile-less root was already refused upstream;
+    // the pip form is the total fallback the contract requires).
+    const manager = pythonInstallStrategy.strategy(join(ctx.cwd, ctx.rootDir))?.manager;
+    switch (manager) {
+      case 'poetry':
+        return { bin: 'poetry', args: ctx.dev ? ['add', '--group', 'dev', spec] : ['add', spec] };
+      case 'uv':
+        return { bin: 'uv', args: ctx.dev ? ['add', '--dev', spec] : ['add', spec] };
+      case 'pipenv':
+        return { bin: 'pipenv', args: ctx.dev ? ['install', '--dev', spec] : ['install', spec] };
+      default:
+        return { bin: 'pip', args: ['install', spec] };
+    }
+  },
+  execution: () => PYTHON_INSTALL_EXECUTION,
+};
+
+/** The python pack's remediation declarations: all four capabilities. The
+ *  resync command rides `pythonInstallStrategy` (a requirements root has no
+ *  lockfile and refuses at the executor with the reason) and the lint fix
+ *  rides the ruff `fixCommand` (Rule 2: one code path each). */
+export const pythonRemediation: RemediationSupport = {
+  resyncLockfile: {
+    kind: 'capability',
+    provider: { manifestFiles: ['pyproject.toml', 'Pipfile', 'requirements.txt'] },
+  },
+  pinTransitive: { kind: 'capability', provider: pythonPinTransitive },
+  declareDependency: { kind: 'capability', provider: pythonDeclareDependency },
+  lintFix: { kind: 'capability' },
+};

--- a/src/languages/python-remediation.ts
+++ b/src/languages/python-remediation.ts
@@ -43,8 +43,10 @@ import type {
   ManifestTextEdit,
   PinPlanResult,
   PinTransitiveProvider,
+  PinVersionScheme,
   RemediationSupport,
 } from './capabilities/remediation';
+import { compareNumericSegments } from './capabilities/remediation';
 import { pyDistForImport } from './python-dist-names';
 import { pythonInstallStrategy, PYTHON_INSTALL_EXECUTION } from './python-install';
 
@@ -65,6 +67,13 @@ function directDepRefusal(pkg: string): string {
 }
 
 // ── TOML text surgery (line-level, style-preserving, refusal-biased) ──────
+// Documented residual: a TOML multiline string containing a line shaped
+// like a `[table]` header (or a `key = [` array opener) can false-match
+// these line-level scans. The worst outcome is an INERT pin (the entry
+// lands inside the string) or an over-refusal; the recipe's verify
+// (re-audit) then fails and the runner discards the diff, so a corrupt
+// manifest never lands. Full TOML parsing is deliberately not worth that
+// tail risk here.
 
 /** The `[name]` table in `lines`: header index and exclusive body end. */
 function findTomlTable(
@@ -133,11 +142,13 @@ function tableArrayRequirementNames(
 
 const norm = (n: string): string => n.toLowerCase().replace(/[-_.]+/g, '-');
 
-/** Is `pkg` a direct dependency under PEP 621 (`[project]` dependencies +
- *  `[project.optional-dependencies]` groups)? */
+/** Is `pkg` a direct dependency under PEP 621 (`[project]` dependencies,
+ *  `[project.optional-dependencies]` groups, and PEP 735
+ *  `[dependency-groups]`, uv's default dev home and what the pack's own
+ *  `uv add --dev` writes)? */
 function directInPep621(lines: readonly string[], pkg: string): boolean {
   const target = norm(pkg);
-  for (const name of ['project', 'project.optional-dependencies']) {
+  for (const name of ['project', 'project.optional-dependencies', 'dependency-groups']) {
     const table = findTomlTable(lines, name);
     if (table && tableArrayRequirementNames(lines, table).some((n) => norm(n) === target)) {
       return true;
@@ -215,7 +226,10 @@ function poetryPinTransform(pkg: string, version: string): ManifestTextEdit['tra
           'explicit-entry pin has nowhere to land; this pin stays on the agent tier',
       };
     }
-    lines.splice(table.header + 1, 0, `${pkg} = "${version}"`);
+    // The key is ALWAYS quoted: a dotted name (zope.interface) inserted
+    // bare would parse as a DOTTED key (a table "zope" with an "interface"
+    // entry), a different dependency entirely.
+    lines.splice(table.header + 1, 0, `"${pkg}" = "${version}"`);
     return { text: lines.join('\n') };
   };
 }
@@ -239,16 +253,33 @@ function pipfilePinTransform(pkg: string, version: string): ManifestTextEdit['tr
           'nowhere to land; this pin stays on the agent tier',
       };
     }
-    lines.splice(table.header + 1, 0, `${pkg} = "==${version}"`);
+    // Quoted key always: a dotted name would otherwise parse as a dotted
+    // key (see the poetry transform).
+    lines.splice(table.header + 1, 0, `"${pkg}" = "==${version}"`);
     return { text: lines.join('\n') };
   };
 }
 
 // ── the providers ──────────────────────────────────────────────────────────
 
+/**
+ * The python pin-version grammar (Rule 6): PyPI advisories carry PEP 440
+ * versions, where a plain release may have ANY number of segments (`2.31`
+ * is concrete; npm's x.y.z default would tier every 2-segment fix to the
+ * agent). Only plain release segments are accepted: epochs, pre/post/dev
+ * markers, local versions, wildcards and ranges refuse (false-negative
+ * bias: a form the numeric comparator cannot order confidently is never
+ * guessed).
+ */
+const pythonPinVersions: PinVersionScheme = {
+  concrete: (v) => /^\d+(\.\d+){0,5}$/.test(v),
+  compare: compareNumericSegments,
+};
+
 const pythonPinTransitive: PinTransitiveProvider = {
   manifestFiles: ['pyproject.toml', 'Pipfile'],
   osvEcosystem: 'PyPI',
+  versions: pythonPinVersions,
   plan(ctx): PinPlanResult {
     // Rule 11: both tokens land in manifest text verbatim; anything outside
     // the ecosystem's own name/version shapes is refused before any edit.
@@ -310,10 +341,19 @@ const pythonDeclareDependency: DeclareDependencyProvider = {
   // answer: an import that maps to no single distribution (malformed, or an
   // ambiguous alias like cv2/google) never reaches an argv.
   validSpecifier: (specifier) => pyDistForImport(specifier) !== null,
-  versionProbe: (ctx) => ({
-    bin: 'pip',
-    args: ['index', 'versions', pyDistForImport(ctx.specifier) ?? ctx.specifier],
-  }),
+  versionProbe(ctx) {
+    const dist = pyDistForImport(ctx.specifier) ?? ctx.specifier;
+    // A uv-managed root probes through uv itself: uv seeds its venvs
+    // WITHOUT pip, so `pip index` may not exist there. The dry-run
+    // resolves the version the install would take without touching the
+    // environment. Every other manager rides pip, which ships with the
+    // python toolchain dxkit requires.
+    const manager = pythonInstallStrategy.strategy(join(ctx.cwd, ctx.rootDir))?.manager;
+    if (manager === 'uv') {
+      return { bin: 'uv', args: ['pip', 'install', '--dry-run', '--no-deps', dist] };
+    }
+    return { bin: 'pip', args: ['index', 'versions', dist] };
+  },
   parseProbeOutput(output) {
     // `pip index versions requests` → `requests (2.32.5)` then an
     // `Available versions:` list; either names the latest first.
@@ -322,8 +362,14 @@ const pythonDeclareDependency: DeclareDependencyProvider = {
       if (m) return m[1];
     }
     const avail = output.match(/Available versions:\s*(\d[^\s,]*)/);
-    return avail ? avail[1] : null;
+    if (avail) return avail[1];
+    // uv's dry-run shape: ` + requests==2.32.5`.
+    const uv = output.match(/^\s*\+\s+[A-Za-z0-9._-]+==(\d\S*)\s*$/m);
+    return uv ? uv[1] : null;
   },
+  // uv without a provisioned project venv errors before resolving; that is
+  // an environment fact, never a verdict on the specifier.
+  probeInfrastructure: (output) => /no virtual environment found/i.test(output),
   installCommand(ctx) {
     const dist = pyDistForImport(ctx.specifier) ?? ctx.specifier;
     const spec = `${dist}==${ctx.version}`;

--- a/src/languages/python.ts
+++ b/src/languages/python.ts
@@ -1,5 +1,4 @@
 import { NO_TREE_INVARIANTS } from './capabilities/tree-invariants';
-import { plannedRemediationSupport } from './capabilities/remediation';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -24,10 +23,15 @@ import type {
   CorrectnessCommand,
   CorrectnessContext,
   CorrectnessProvider,
+  LockfileCheck,
   ResolutionCheckResult,
 } from './capabilities/correctness';
+import { lockfileCheckFromStrategy } from './capabilities/correctness';
 import type { ExecutionRequirement } from '../execution';
-import { declareInstallStrategy } from './capabilities/install-strategy';
+import { resolveTolerances } from '../install/tolerances';
+import { pythonInstallStrategy } from './python-install';
+import { pythonRemediation } from './python-remediation';
+import { PY_MODULE_DIST_ALIASES } from './python-dist-names';
 import type {
   CoverageResult,
   DepVulnFinding,
@@ -563,6 +567,7 @@ const pyDepVulnsProvider: DepVulnsProvider = {
     'Pipfile',
     'Pipfile.lock',
     'poetry.lock',
+    'uv.lock',
   ],
   // A nested requirements.txt / pyproject.toml resolves its own
   // environment (separate services in one repo), unlike a package of a
@@ -1214,40 +1219,6 @@ const PY_STDLIB = new Set([
   'zoneinfo',
 ]);
 
-/** Import-name → PyPI distribution names for the well-known mismatches
- *  (`import yaml` installs as `pyyaml`). Consulted only on the DECLARED
- *  side — an installed module is found in site-packages under its import
- *  name regardless. KNOWN pairs only (false-negative bias). */
-const PY_MODULE_DIST_ALIASES: Readonly<Record<string, readonly string[]>> = {
-  yaml: ['pyyaml'],
-  PIL: ['pillow'],
-  sklearn: ['scikit-learn', 'scikit_learn'],
-  bs4: ['beautifulsoup4'],
-  cv2: ['opencv-python', 'opencv-python-headless', 'opencv_python'],
-  dotenv: ['python-dotenv', 'python_dotenv'],
-  dateutil: ['python-dateutil', 'python_dateutil'],
-  jose: ['python-jose', 'python_jose'],
-  jwt: ['pyjwt'],
-  Crypto: ['pycryptodome', 'pycrypto'],
-  magic: ['python-magic', 'python_magic'],
-  git: ['gitpython'],
-  github: ['pygithub'],
-  docx: ['python-docx', 'python_docx'],
-  pptx: ['python-pptx', 'python_pptx'],
-  slugify: ['python-slugify', 'python_slugify'],
-  MySQLdb: ['mysqlclient'],
-  psycopg2: ['psycopg2-binary', 'psycopg2_binary'],
-  attr: ['attrs'],
-  serial: ['pyserial'],
-  usb: ['pyusb'],
-  OpenSSL: ['pyopenssl'],
-  wx: ['wxpython'],
-  fitz: ['pymupdf'],
-  kafka: ['kafka-python', 'kafka_python'],
-  snowflake: ['snowflake-connector-python', 'snowflake_connector_python'],
-  google: ['protobuf', 'google-api-python-client', 'google-cloud-storage'],
-};
-
 /** Repo-local virtualenv site-packages directories (`.venv` / `venv`,
  *  POSIX `lib/pythonX.Y/site-packages` and Windows `Lib/site-packages`).
  *  The Python analog of "does node_modules exist". */
@@ -1421,6 +1392,17 @@ export function pyResolutionCheck(ctx: CorrectnessContext): ResolutionCheckResul
 const pyCorrectnessProvider: CorrectnessProvider = {
   resolutionCheck: pyResolutionCheck,
 
+  // The lockfile-sync check (4.4.7): would the manager's frozen install of
+  // this tree succeed? Derived from the strategy's own declared sync check
+  // through the ONE derivation (`lockfileCheckFromStrategy`), so the check
+  // and the install read one declaration. No lockfile (a plain
+  // requirements root) → nothing to keep in sync → null.
+  lockfileCheck(ctx: CorrectnessContext): LockfileCheck | null {
+    const strategy = pythonInstallStrategy.strategy(ctx.cwd);
+    if (strategy === null || strategy.lockfile === null) return null;
+    return lockfileCheckFromStrategy(strategy, ctx.tolerances ?? resolveTolerances(ctx.cwd));
+  },
+
   // Rule 20: host-agnostic, needs the Python runtime; py_compile + pytest run
   // the project's own code — 'build' weight without a compiled-build env.
   execution: (): ExecutionRequirement => ({
@@ -1506,6 +1488,23 @@ const pyLintGateProvider: LintGateProvider = {
       // humans, and a diagnostic whose message breaks the line shape is
       // silently dropped by a display regex (the eslint class, Rule 5).
       args: ['check', '.', '--output-format', 'json'],
+      parse: { kind: 'structured', label: 'ruff-json', parse: parseRuffJson },
+      expectedExit: 0,
+    };
+  },
+  // The lint-autofix recipe's fix mode (4.4.7): `ruff check --fix` scoped to
+  // the work order's files. One run both writes the fixes and reports the
+  // REMAINING (unfixable) findings through the SAME json parser the gate
+  // uses, so the recipe's verify reads the leftovers of the very command
+  // that fixed. ruff exits non-zero when findings remain; the recipe parses
+  // regardless of exit (the seam's own doctrine).
+  fixCommand(ctx) {
+    if (ctx.files.length === 0) return null;
+    const ruff = findTool(TOOL_DEFS.ruff, ctx.cwd);
+    if (!ruff.available || !ruff.path) return null;
+    return {
+      bin: ruff.path,
+      args: ['check', '--fix', '--output-format', 'json', ...ctx.files],
       parse: { kind: 'structured', label: 'ruff-json', parse: parseRuffJson },
       expectedExit: 0,
     };
@@ -1733,67 +1732,6 @@ function detectPythonVersion(cwd: string): string | undefined {
   return undefined;
 }
 
-const PYTHON_INSTALL_EXECUTION: ExecutionRequirement = {
-  hosts: ['any'],
-  toolchains: ['python'],
-  needsBuild: false,
-  buildTarget: 'none',
-  weight: 'cheap',
-};
-
-const pythonInstallStrategy = declareInstallStrategy(
-  [
-    {
-      when: ['poetry.lock'],
-      strategy: {
-        manager: 'poetry',
-        lockfile: 'poetry.lock',
-        modes: { frozen: { primary: { bin: 'poetry', args: ['install'] }, fallbacks: [] } },
-        execution: PYTHON_INSTALL_EXECUTION,
-      },
-    },
-    {
-      when: ['uv.lock'],
-      strategy: {
-        manager: 'uv',
-        lockfile: 'uv.lock',
-        modes: {
-          frozen: { primary: { bin: 'uv', args: ['sync', '--locked'] }, fallbacks: [] },
-          resync: { primary: { bin: 'uv', args: ['sync'] }, fallbacks: [] },
-        },
-        execution: PYTHON_INSTALL_EXECUTION,
-      },
-    },
-    {
-      when: ['Pipfile.lock'],
-      strategy: {
-        manager: 'pipenv',
-        lockfile: 'Pipfile.lock',
-        modes: {
-          frozen: { primary: { bin: 'pipenv', args: ['install', '--deploy'] }, fallbacks: [] },
-          resync: { primary: { bin: 'pipenv', args: ['install'] }, fallbacks: [] },
-        },
-        execution: PYTHON_INSTALL_EXECUTION,
-      },
-    },
-    {
-      when: ['requirements.txt'],
-      strategy: {
-        manager: 'pip',
-        lockfile: null,
-        modes: {
-          frozen: {
-            primary: { bin: 'pip', args: ['install', '-r', 'requirements.txt'] },
-            fallbacks: [],
-          },
-        },
-        execution: PYTHON_INSTALL_EXECUTION,
-      },
-    },
-  ],
-  { ciDependencyInstall: false },
-);
-
 export const python: LanguageSupport = {
   id: 'python',
   displayName: 'Python',
@@ -1828,14 +1766,9 @@ export const python: LanguageSupport = {
   tlsBypassPatterns: ['verify[[:space:]]*=[[:space:]]*False', 'VERIFY_SSL.*[Ff]alse'],
 
   // How a python root installs (Rule 6): one variant per dependency
-  // artifact, in preference order. The frozen forms are the ones that
-  // REFUSE a stale lockfile (`uv sync --locked`, `pipenv install --deploy`,
-  // and `poetry install`, which aborts when pyproject moved ahead of
-  // poetry.lock); a resync is declared only where ONE command both
-  // rewrites the lockfile and installs (uv, pipenv). Poetry needs
-  // `poetry lock` first and plain requirements have no lockfile, so
-  // neither declares one. No ecosystem tolerance exists here: python
-  // resolvers have no peer-check analogue, so no fallbacks are declared.
+  // artifact, in preference order; declarations + doctrine live in
+  // python-install.ts (the node-install.ts split), shared with the
+  // remediation capabilities.
   installStrategy: pythonInstallStrategy,
 
   upgradeCommand(name, version) {
@@ -2060,7 +1993,7 @@ export const python: LanguageSupport = {
   },
 
   treeInvariants: NO_TREE_INVARIANTS,
-  remediation: plannedRemediationSupport('python'),
+  remediation: pythonRemediation,
   correctness: pyCorrectnessProvider,
   lintGate: pyLintGateProvider,
 

--- a/src/languages/python.ts
+++ b/src/languages/python.ts
@@ -31,7 +31,7 @@ import type { ExecutionRequirement } from '../execution';
 import { resolveTolerances } from '../install/tolerances';
 import { pythonInstallStrategy } from './python-install';
 import { pythonRemediation } from './python-remediation';
-import { PY_MODULE_DIST_ALIASES } from './python-dist-names';
+import { normalizePyDistName, PY_MODULE_DIST_ALIASES } from './python-dist-names';
 import type {
   CoverageResult,
   DepVulnFinding,
@@ -1252,7 +1252,9 @@ export function pySitePackagesDirs(cwd: string): string[] {
  *  lowercase-with-underscores. Regex extraction, biased toward capturing
  *  MORE names (an over-captured token can only suppress a finding). */
 export function pyDeclaredDeps(cwd: string): Set<string> {
-  const norm = (n: string): string => n.toLowerCase().replace(/-/g, '_');
+  // The ONE name fold (PEP 503, python-dist-names.ts), shared with the
+  // alias table so spelling variants need no duplicate entries.
+  const norm = normalizePyDistName;
   const out = new Set<string>();
   let entries: string[] = [];
   try {
@@ -1363,12 +1365,10 @@ export function pyResolutionCheck(ctx: CorrectnessContext): ResolutionCheckResul
             isFile(path.join(d, `${top}.py`)) ||
             isFile(path.join(d, `${top}.pyi`)),
         ) || resolvePyImportRaw(rel, spec, cwd, roots) !== null;
-      const normTop = top.toLowerCase().replace(/-/g, '_');
+      const normTop = normalizePyDistName(top);
       const declaredHit =
         declared.has(normTop) ||
-        (PY_MODULE_DIST_ALIASES[top] ?? []).some((d) =>
-          declared.has(d.toLowerCase().replace(/-/g, '_')),
-        );
+        (PY_MODULE_DIST_ALIASES[top] ?? []).some((d) => declared.has(normalizePyDistName(d)));
       if (installed || declaredHit) resolvedTops.add(top);
       else unresolved.set(top, rel);
     }

--- a/src/languages/ruby-remediation.ts
+++ b/src/languages/ruby-remediation.ts
@@ -1,0 +1,146 @@
+/**
+ * The ruby ecosystem's remediation capabilities (the pack's `remediation`,
+ * Rule 6, the node-remediation.ts sibling): every bundler/rubygems fact
+ * the recipe executors consume through the capability seam.
+ *
+ * Doctrine notes, kept beside the declarations they explain:
+ *   - Bundler has NO transitive-override mechanism; its community-standard
+ *     fix is the EXPLICIT-ENTRY pin: declare the gem directly in the
+ *     Gemfile at the exact patched version so the resolver must take it.
+ *     The edit is a pure append at the top level (groups and platforms
+ *     above are untouched), refused when the gem is already declared
+ *     directly (the honest fix is upgrading the declared dependency, the
+ *     dep-bump lane's job) or when the text does not look like a Gemfile.
+ *   - `bundle add <gem> --version <v>` both edits the Gemfile and
+ *     installs, and a plain version string is an exact requirement, so the
+ *     declare capability rides it rather than a second Gemfile writer.
+ *   - Ruby require names and gem names diverge (`active_support` is the
+ *     gem activesupport); the resolution check folds them when READING,
+ *     but declaring must never guess which gem an unmatched require means.
+ *     The identity mapping plus the registry probe is the honest rail: a
+ *     require that is not itself a published gem name fails the
+ *     `gem search --exact` probe and refuses, never installs a guess.
+ *   - The version probe is `gem search --remote --exact`, which resolves
+ *     against the sources the repo's rubygems configuration declares.
+ */
+import type { ExecutionRequirement } from '../execution';
+import type {
+  DeclareDependencyProvider,
+  ManifestTextEdit,
+  PinPlanResult,
+  PinTransitiveProvider,
+  RemediationSupport,
+} from './capabilities/remediation';
+
+/** Remediation commands run on the ambient ruby toolchain (bundler and gem
+ *  ship with it), any host, no build. */
+const RUBY_REMEDIATION_EXECUTION: ExecutionRequirement = {
+  hosts: ['any'],
+  toolchains: ['ruby'],
+  needsBuild: false,
+  buildTarget: 'none',
+  weight: 'cheap',
+};
+
+/**
+ * A RubyGems gem-name shape. Load-bearing for the Rule 11 argument-
+ * injection discipline: a specifier is attacker-influencable source text,
+ * and a leading dash handed to `gem`/`bundle` argv is a flag. No slash:
+ * a nested require path (`active_support/core_ext`) names a FILE inside a
+ * gem, not a gem, and stays on the agent tier.
+ */
+const GEM_NAME = /^[A-Za-z0-9][A-Za-z0-9_.-]*$/;
+
+export function isValidGemName(name: string): boolean {
+  return name.length > 0 && name.length <= 100 && GEM_NAME.test(name);
+}
+
+/** A rubygems version shape (digits-led; letters cover prereleases). */
+const GEM_VERSION = /^[0-9][0-9A-Za-z.-]*$/;
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** The explicit-entry pin as a PURE text transform: append the exact-
+ *  version gem line at the Gemfile's top level. */
+function gemfilePinTransform(pkg: string, version: string): ManifestTextEdit['transform'] {
+  return (text) => {
+    if (!/^\s*(source|gem|gemspec)\b/m.test(text)) {
+      return { refused: 'this file does not look like a Gemfile, so it cannot be edited' };
+    }
+    if (new RegExp(`^\\s*gem\\s+["']${escapeRegExp(pkg)}["']`, 'm').test(text)) {
+      return {
+        refused:
+          `'${pkg}' is already declared in this Gemfile; the honest fix is upgrading the ` +
+          'declared dependency (the dep-bump lane), not pinning it again',
+      };
+    }
+    const base = text.endsWith('\n') ? text : `${text}\n`;
+    return {
+      text:
+        `${base}\n# Pins a transitive dependency to a patched version; remove once the\n` +
+        `# dependency tree moves past it.\ngem "${pkg}", "${version}"\n`,
+    };
+  };
+}
+
+const rubyPinTransitive: PinTransitiveProvider = {
+  manifestFiles: ['Gemfile'],
+  osvEcosystem: 'RubyGems',
+  plan(ctx): PinPlanResult {
+    // Rule 11: both tokens land in manifest text verbatim.
+    if (!isValidGemName(ctx.pkg) || !GEM_VERSION.test(ctx.version)) {
+      return {
+        kind: 'refused',
+        reason: `'${ctx.pkg}@${ctx.version}' is not a gem name + version shape dxkit will write into a Gemfile`,
+      };
+    }
+    const at = ctx.rootDir ? `${ctx.rootDir}/` : '';
+    return {
+      kind: 'plan',
+      edit: { file: 'Gemfile', transform: gemfilePinTransform(ctx.pkg, ctx.version) },
+      revert: `remove the pinned 'gem "${ctx.pkg}"' entry from ${at}Gemfile and re-run the lock resync`,
+    };
+  },
+  execution: () => RUBY_REMEDIATION_EXECUTION,
+};
+
+const rubyDeclareDependency: DeclareDependencyProvider = {
+  manifestFiles: ['Gemfile'],
+  osvEcosystem: 'RubyGems',
+  packageNameLabel: 'gem name',
+  validSpecifier: isValidGemName,
+  versionProbe: (ctx) => ({
+    bin: 'gem',
+    args: ['search', '--remote', '--exact', ctx.specifier],
+  }),
+  parseProbeOutput(output) {
+    // `gem search -r -e nokogiri` → `nokogiri (1.16.5)`, possibly with
+    // platform variants after a comma; the first token is the version.
+    for (const line of output.split('\n')) {
+      const m = line.match(/^\s*[A-Za-z0-9_.-]+\s+\((\d[^)\s,]*)[^)]*\)/);
+      if (m) return m[1];
+    }
+    return null;
+  },
+  installCommand(ctx) {
+    // `bundle add` edits the Gemfile AND installs; a plain version string
+    // is an exact requirement. Test-only importers land in :development.
+    const args = ['add', ctx.specifier, '--version', ctx.version];
+    if (ctx.dev) args.push('--group', 'development');
+    return { bin: 'bundle', args };
+  },
+  execution: () => RUBY_REMEDIATION_EXECUTION,
+};
+
+/** The ruby pack's remediation declarations. The resync command rides the
+ *  pack's install strategy (`bundle install` resolves, writes Gemfile.lock
+ *  and installs in one command) and the lint fix rides the rubocop
+ *  `fixCommand` (Rule 2: one code path each). */
+export const rubyRemediation: RemediationSupport = {
+  resyncLockfile: { kind: 'capability', provider: { manifestFiles: ['Gemfile'] } },
+  pinTransitive: { kind: 'capability', provider: rubyPinTransitive },
+  declareDependency: { kind: 'capability', provider: rubyDeclareDependency },
+  lintFix: { kind: 'capability' },
+};

--- a/src/languages/ruby-remediation.ts
+++ b/src/languages/ruby-remediation.ts
@@ -29,8 +29,10 @@ import type {
   ManifestTextEdit,
   PinPlanResult,
   PinTransitiveProvider,
+  PinVersionScheme,
   RemediationSupport,
 } from './capabilities/remediation';
+import { compareNumericSegments } from './capabilities/remediation';
 
 /** Remediation commands run on the ambient ruby toolchain (bundler and gem
  *  ship with it), any host, no build. */
@@ -63,7 +65,14 @@ function escapeRegExp(s: string): string {
 }
 
 /** The explicit-entry pin as a PURE text transform: append the exact-
- *  version gem line at the Gemfile's top level. */
+ *  version gem line at the Gemfile's top level.
+ *
+ *  Documented residual: a Gemfile whose dependencies come through a
+ *  `gemspec` directive declares them in the .gemspec, which this transform
+ *  does not read, so a gem direct there is not refused here. The append is
+ *  still safe: an incompatible explicit pin fails the resync loudly
+ *  (bundler cannot resolve both constraints) and the runner discards the
+ *  diff; nothing lands silently wrong. */
 function gemfilePinTransform(pkg: string, version: string): ManifestTextEdit['transform'] {
   return (text) => {
     if (!/^\s*(source|gem|gemspec)\b/m.test(text)) {
@@ -85,9 +94,22 @@ function gemfilePinTransform(pkg: string, version: string): ManifestTextEdit['tr
   };
 }
 
+/**
+ * The ruby pin-version grammar (Rule 6): RubyGems security releases are
+ * routinely FOUR-segment (the rails family ships 7.0.8.7-style fixes, the
+ * highest-volume gem advisory class), which npm's x.y.z default would tier
+ * to the agent wholesale. Plain numeric release segments only; prerelease
+ * letters, ranges and wildcards refuse (false-negative bias).
+ */
+const rubyPinVersions: PinVersionScheme = {
+  concrete: (v) => /^\d+(\.\d+){0,4}$/.test(v),
+  compare: compareNumericSegments,
+};
+
 const rubyPinTransitive: PinTransitiveProvider = {
   manifestFiles: ['Gemfile'],
   osvEcosystem: 'RubyGems',
+  versions: rubyPinVersions,
   plan(ctx): PinPlanResult {
     // Rule 11: both tokens land in manifest text verbatim.
     if (!isValidGemName(ctx.pkg) || !GEM_VERSION.test(ctx.version)) {

--- a/src/languages/ruby.ts
+++ b/src/languages/ruby.ts
@@ -1,5 +1,5 @@
 import { NO_TREE_INVARIANTS } from './capabilities/tree-invariants';
-import { plannedRemediationSupport } from './capabilities/remediation';
+import { rubyRemediation } from './ruby-remediation';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -20,9 +20,12 @@ import type {
   CorrectnessCommand,
   CorrectnessContext,
   CorrectnessProvider,
+  LockfileCheck,
   ResolutionCheckResult,
 } from './capabilities/correctness';
+import { lockfileCheckFromStrategy } from './capabilities/correctness';
 import type { ExecutionRequirement } from '../execution';
+import { resolveTolerances } from '../install/tolerances';
 import { declareInstallStrategy } from './capabilities/install-strategy';
 import type {
   CoverageResult,
@@ -931,6 +934,16 @@ export function rubyResolutionCheck(ctx: CorrectnessContext): ResolutionCheckRes
 const rubyCorrectnessProvider: CorrectnessProvider = {
   resolutionCheck: rubyResolutionCheck,
 
+  // The lockfile-sync check (4.4.7), derived from the strategy's own
+  // declared sync check through the ONE derivation. Bundler's is a
+  // DISCLOSED skip (no non-installing dry-run exists), so the floor says
+  // why instead of silently observing nothing.
+  lockfileCheck(ctx: CorrectnessContext): LockfileCheck | null {
+    const strategy = rubyInstallStrategy.strategy(ctx.cwd);
+    if (strategy === null || strategy.lockfile === null) return null;
+    return lockfileCheckFromStrategy(strategy, ctx.tolerances ?? resolveTolerances(ctx.cwd));
+  },
+
   // Rule 20: host-agnostic, needs the Ruby runtime; the floor runs the
   // project's own specs — 'build' weight without a compiled-build env.
   execution: (): ExecutionRequirement => ({
@@ -996,6 +1009,21 @@ const rubyCorrectnessProvider: CorrectnessProvider = {
  *  identities carry over. Exported so the lint-gate format contract is
  *  testable against real samples. */
 export function parseRubocopJson(output: string): RawLocatedFinding[] {
+  return mapRubocopOffenses(output, { excludeCorrected: false });
+}
+
+/** The fix-mode sibling: under `rubocop -a` an offense the run CORRECTED
+ *  still appears in the json with `corrected: true`; only the leftovers
+ *  are findings, or the recipe's verify would fail on its own fixes.
+ *  Exported so the filter is testable against a real `-a` sample. */
+export function parseRubocopFixJson(output: string): RawLocatedFinding[] {
+  return mapRubocopOffenses(output, { excludeCorrected: true });
+}
+
+function mapRubocopOffenses(
+  output: string,
+  opts: { excludeCorrected: boolean },
+): RawLocatedFinding[] {
   const data = asRecord(extractJsonBlob(output));
   if (!data || !Array.isArray(data.files)) return [];
   const out: RawLocatedFinding[] = [];
@@ -1007,6 +1035,7 @@ export function parseRubocopJson(output: string): RawLocatedFinding[] {
       const offense = asRecord(raw);
       const message = str(offense?.message);
       if (!offense || !message) continue;
+      if (opts.excludeCorrected && offense.corrected === true) continue;
       const line = num(asRecord(offense.location)?.line);
       const rule = str(offense.cop_name);
       out.push({
@@ -1038,6 +1067,23 @@ const rubyLintGateProvider: LintGateProvider = {
       // ABSOLUTE paths and a lossy one-line render (Rule 5).
       args: ['--format', 'json'],
       parse: { kind: 'structured', label: 'rubocop-json', parse: parseRubocopJson },
+      expectedExit: 0,
+    };
+  },
+  // The lint-autofix recipe's fix mode (4.4.7): `rubocop -a` (SAFE
+  // autocorrect only, never -A) scoped to the work order's files. One run
+  // both writes the fixes and reports the leftovers through the fix-mode
+  // parser, which drops offenses the run itself corrected; rubocop exits
+  // non-zero when offenses remain and the recipe parses regardless of exit
+  // (the seam's own doctrine).
+  fixCommand(ctx) {
+    if (ctx.files.length === 0) return null;
+    const rubocop = findTool(TOOL_DEFS.rubocop, ctx.cwd);
+    if (!rubocop.available || !rubocop.path) return null;
+    return {
+      bin: rubocop.path,
+      args: ['-a', '--format', 'json', ...ctx.files],
+      parse: { kind: 'structured', label: 'rubocop-fix-json', parse: parseRubocopFixJson },
       expectedExit: 0,
     };
   },
@@ -1078,7 +1124,21 @@ const rubyInstallStrategy = declareInstallStrategy(
       strategy: {
         manager: 'bundler',
         lockfile: 'Gemfile.lock',
-        modes: { frozen: { primary: { bin: 'bundle', args: ['install'] }, fallbacks: [] } },
+        modes: {
+          frozen: { primary: { bin: 'bundle', args: ['install'] }, fallbacks: [] },
+          // `bundle install` resolves the Gemfile, writes Gemfile.lock and
+          // installs in one command (bundler's own lock-writing form); a
+          // repo frozen via BUNDLE_FROZEN fails it named, never silently.
+          resync: { primary: { bin: 'bundle', args: ['install'] }, fallbacks: [] },
+        },
+        syncCheck: {
+          kind: 'skipped',
+          reason:
+            'bundler has no non-installing dry-run that compares the Gemfile to ' +
+            'Gemfile.lock (bundle check needs installed gems and may rewrite the ' +
+            'lockfile); a frozen install under BUNDLE_FROZEN refuses a stale ' +
+            'lockfile and CI is the backstop',
+        },
         execution: {
           hosts: ['any'],
           toolchains: ['ruby'],
@@ -1244,7 +1304,7 @@ export const ruby: LanguageSupport = {
   },
 
   treeInvariants: NO_TREE_INVARIANTS,
-  remediation: plannedRemediationSupport('ruby'),
+  remediation: rubyRemediation,
   correctness: rubyCorrectnessProvider,
   lintGate: rubyLintGateProvider,
 

--- a/src/remediate/recipes/declare-dependency.ts
+++ b/src/remediate/recipes/declare-dependency.ts
@@ -135,7 +135,28 @@ export async function executeDeclareDependency(
         output: `${probe.bin} is not available here`,
       };
     }
-    if (view.timedOut || view.overflowed || view.code !== 0) {
+    if (view.timedOut || view.overflowed) {
+      return {
+        kind: 'failed',
+        step: 'resolve-version',
+        output: `${probe.bin} ${view.timedOut ? 'timed out' : 'overflowed the capture buffer'}`,
+      };
+    }
+    if (view.code !== 0) {
+      // An infrastructure-shaped probe failure (an old CLI without the
+      // probe subcommand, an unprovisioned environment) is a named failure
+      // of THIS run, never a verdict on the specifier: the generic tool-CLI
+      // shapes here, plus whatever the pack declares (Rule 6).
+      const infrastructure =
+        /unknown command|no such command|command not found|is not recognized/i.test(view.output) ||
+        (provider.probeInfrastructure?.(view.output) ?? false);
+      if (infrastructure) {
+        return {
+          kind: 'failed',
+          step: 'resolve-version',
+          output: `${probe.bin} cannot answer a version probe here: ${view.output.trim().split('\n')[0] ?? ''}`,
+        };
+      }
       return {
         kind: 'refused',
         reason:

--- a/src/remediate/recipes/override-pin.ts
+++ b/src/remediate/recipes/override-pin.ts
@@ -31,6 +31,7 @@ import {
   osvBlockTier,
   packStrategyAt,
   pickPinVersion,
+  pinVersionScheme,
   resolvePinCapability,
   runResyncInstall,
 } from './shared';
@@ -90,17 +91,18 @@ export async function executeOverridePin(
     };
   }
 
-  // The pin: the highest known CONCRETE fixed version clears every advisory
-  // at once. Prerelease-aware (1.2.3 outranks 1.2.3-beta.1); a range-shaped
-  // fixed string refuses rather than guesses (the registry's `matches`
-  // already tiers such orders to the agent, so this is the defensive rail).
-  const pin = pickPinVersion(fixedVersions);
+  // The pin: the highest known CONCRETE fixed version (under the owning
+  // pack's declared version grammar, the same scheme the registry's
+  // `matches` graded) clears every advisory at once. A range-shaped fixed
+  // string refuses rather than guesses (the planner already tiers such
+  // orders to the agent, so this is the defensive rail).
+  const pin = pickPinVersion(fixedVersions, pinVersionScheme(provider));
   if (pin === null) {
     return {
       kind: 'refused',
       reason:
-        `the known fixed versions for '${pkg}' are not all concrete semver values ` +
-        `(${fixedVersions.join(', ')}); a range cannot be pinned verbatim`,
+        `the known fixed versions for '${pkg}' are not all concrete versions this ` +
+        `ecosystem can pin verbatim (${fixedVersions.join(', ')})`,
     };
   }
 
@@ -109,7 +111,9 @@ export async function executeOverridePin(
   const plan = provider.plan({ cwd: ctx.cwd, rootDir, pkg, version: pin });
   if (plan.kind === 'refused') return { kind: 'refused', reason: plan.reason };
 
-  const notes: string[] = [];
+  // Pack-declared side-effect disclosures ride the ledger (composer's lock
+  // resync may refresh unrelated packages).
+  const notes: string[] = [...(plan.notes ?? [])];
 
   // $0 pre-check: would the pinned version itself carry a block-tier
   // advisory? A null answer (network) is disclosed and the re-audit verify

--- a/src/remediate/recipes/shared.ts
+++ b/src/remediate/recipes/shared.ts
@@ -21,6 +21,7 @@ import { getLanguage, languagesDeclaringRemediation, remediationSupport } from '
 import type { LanguageId } from '../../languages/types';
 import type {
   PinTransitiveProvider,
+  PinVersionScheme,
   RemediationCapabilityId,
   RemediationSupport,
 } from '../../languages/capabilities/remediation';
@@ -86,12 +87,34 @@ export function compareConcreteSemver(a: string, b: string): number {
   return 0;
 }
 
+/** The default pin-version grammar: the x.y.z semver shape. Packs whose
+ *  advisories carry other concrete forms declare their own
+ *  `PinVersionScheme` (Rule 6); everything here consumes the scheme, never
+ *  the semver helpers directly. */
+export const DEFAULT_PIN_VERSIONS: PinVersionScheme = {
+  concrete: isConcreteSemver,
+  compare: compareConcreteSemver,
+};
+
+/** The version grammar serving a pin provider: its declared scheme, or the
+ *  semver default. The ONE resolution consumed by the registry's `matches`
+ *  and the executor's pick, so the tier decision and the runtime pick can
+ *  never grade a fixed version differently. */
+export function pinVersionScheme(
+  provider: Pick<PinTransitiveProvider, 'versions'>,
+): PinVersionScheme {
+  return provider.versions ?? DEFAULT_PIN_VERSIONS;
+}
+
 /** The pin an override-pin order applies: the highest CONCRETE version among
- *  the known fixed versions, or null when any is range-shaped (refuse, never
- *  guess a range's meaning). */
-export function pickPinVersion(versions: readonly string[]): string | null {
-  if (versions.length === 0 || !versions.every(isConcreteSemver)) return null;
-  return versions.reduce((best, v) => (compareConcreteSemver(v, best) > 0 ? v : best));
+ *  the known fixed versions under the owning pack's version grammar, or
+ *  null when any is range-shaped (refuse, never guess a range's meaning). */
+export function pickPinVersion(
+  versions: readonly string[],
+  scheme: PinVersionScheme = DEFAULT_PIN_VERSIONS,
+): string | null {
+  if (versions.length === 0 || !versions.every((v) => scheme.concrete(v))) return null;
+  return versions.reduce((best, v) => (scheme.compare(v, best) > 0 ? v : best));
 }
 
 /**

--- a/src/remediate/work-orders/recipes-registry.ts
+++ b/src/remediate/work-orders/recipes-registry.ts
@@ -29,9 +29,9 @@ import { executeLintAutofix, lintPackOf } from '../recipes/lint-autofix';
 import { executeLockfileSync } from '../recipes/lockfile-sync';
 import { executeOverridePin } from '../recipes/override-pin';
 import {
-  isConcreteSemver,
   owningManifestRoot,
   packDeclaration,
+  pinVersionScheme,
   resolvePinCapability,
 } from '../recipes/shared';
 import type { RecipeExecuteContext, RecipeOutcome } from '../recipes/types';
@@ -70,6 +70,35 @@ function lintFileOf(order: WorkOrder): string | null {
 function lintOrderPack(order: WorkOrder): string | null {
   const first = order.findings[0]?.evidence;
   return first && first.type === 'custom-check' ? lintPackOf(first.check) : null;
+}
+
+/**
+ * Can the pack's declared sync check VERIFY a resync for this order?
+ * Order-intrinsic (declarations + the order's own envelope, no repo read):
+ * of the pack's install-strategy variants, the ones whose selector files
+ * the envelope names decide (all variants when the envelope names none).
+ * A DECLARED-SKIP sync check (bundler, pnpm, yarn) means the lockfile-sync
+ * executor could NEVER confirm the fix, so running the recipe is a certain
+ * discard: the order tiers agent instead, with the declared skip reason
+ * disclosed (4.4.7 review round). Only the declared skip decides here: a
+ * pack whose `lockfileCheck` does not derive from a strategy sync check
+ * (no syncCheck declared at all) stays on the recipe tier and the
+ * executor's verify remains the runtime authority, so this projection can
+ * never over-rule a verifiable check it cannot see (Rule 2.30).
+ */
+function resyncVerifiableForOrder(
+  pack: string,
+  order: WorkOrder,
+): { ok: true } | { ok: false; reason: string } {
+  const variants = getLanguage(pack as LanguageId)?.installStrategy?.variants() ?? [];
+  const inEnvelope = (f: string): boolean =>
+    order.envelope.paths.some((p) => p === f || p.endsWith(`/${f}`));
+  const matching = variants.filter((v) => v.when.some(inEnvelope));
+  const considered = matching.length > 0 ? matching : variants;
+  if (considered.some((v) => v.strategy.syncCheck?.kind === 'command')) return { ok: true };
+  const skip = considered.map((v) => v.strategy.syncCheck).find((c) => c?.kind === 'skipped');
+  if (skip?.kind === 'skipped') return { ok: false, reason: skip.reason };
+  return { ok: true };
 }
 
 /** A pack's declared exemption for one capability, shaped for the order's
@@ -146,11 +175,26 @@ export const RECIPE_REGISTRY: readonly RecipeDeclaration[] = [
         declaration !== undefined &&
         declaration.kind === 'capability' &&
         owningManifestRoot(order, declaration.provider.manifestFiles) !== null &&
-        getLanguage(pack as LanguageId)?.correctness?.lockfileCheck !== undefined
+        getLanguage(pack as LanguageId)?.correctness?.lockfileCheck !== undefined &&
+        resyncVerifiableForOrder(pack, order).ok
       );
     },
     execute: executeLockfileSync,
-    packExemption: (order) => exemptionOf(floorPackOf(order), 'resyncLockfile'),
+    packExemption: (order) => {
+      const pack = floorPackOf(order);
+      const declared = exemptionOf(pack, 'resyncLockfile');
+      if (declared !== null || pack === null) return declared;
+      // A declared capability whose verify is a declared skip: the certain
+      // discard is disclosed on the order with the pack's own reason.
+      const verifiable = resyncVerifiableForOrder(pack, order);
+      return verifiable.ok
+        ? null
+        : {
+            pack,
+            capability: 'resyncLockfile',
+            reason: `a resync here could never be verified: ${verifiable.reason}`,
+          };
+    },
   },
   {
     id: 'override-pin',
@@ -159,22 +203,25 @@ export const RECIPE_REGISTRY: readonly RecipeDeclaration[] = [
       'pin a fixed version through a pack-declared override when no direct upgrade path exists',
     implemented: true,
     // Needs a known CONCRETE fixed version for EVERY advisory in the order
-    // (a range-shaped fixed string cannot be pinned verbatim), an owning
+    // under the owning pack's declared version grammar (a range-shaped
+    // fixed string cannot be pinned verbatim), an owning
     // pack that declares the pin capability, one owning root under its
     // manifests, and an install command the frame can run; an advisory with
     // no fix is agent (or human) territory.
     matches: (order) => {
       if (order.constraints.install === undefined || order.findings.length === 0) return false;
       const resolved = resolvePinCapability(order);
-      return (
-        resolved.kind === 'capability' &&
-        resolved.rootDir !== null &&
-        order.findings.every(
-          (f) =>
-            f.evidence.type === 'dep-vuln' &&
-            typeof f.evidence.fixedVersion === 'string' &&
-            isConcreteSemver(f.evidence.fixedVersion),
-        )
+      if (resolved.kind !== 'capability' || resolved.rootDir === null) return false;
+      // The owning pack's version grammar decides what is pinnable (Rule 6:
+      // x.y.z semver is an npm fact; RubyGems security releases are
+      // 4-segment, PyPI releases may be 2-segment). Same scheme the
+      // executor's pick reads, so tier and runtime cannot diverge.
+      const scheme = pinVersionScheme(resolved.provider);
+      return order.findings.every(
+        (f) =>
+          f.evidence.type === 'dep-vuln' &&
+          typeof f.evidence.fixedVersion === 'string' &&
+          scheme.concrete(f.evidence.fixedVersion),
       );
     },
     execute: executeOverridePin,

--- a/test/correctness-lockfile-sync.test.ts
+++ b/test/correctness-lockfile-sync.test.ts
@@ -8,6 +8,7 @@ import { getLanguage } from '../src/languages';
 import { clearWalkPathsCache } from '../src/analyzers/tools/walk-paths';
 
 const TS = getLanguage('typescript')!;
+const PY = getLanguage('python')!;
 
 /**
  * The lockfile-sync floor check on the REAL TypeScript pack (4.4.5): the
@@ -340,5 +341,49 @@ describe('lockfile-sync floor check (typescript pack, npm)', () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe('lockfile-sync floor check (python pack, poetry): non-drift classification (4.4.7 V2)', () => {
+  // poetry has no lock-only check: `poetry check --lock` validates the whole
+  // pyproject alongside the lock, so a manifest error would otherwise read,
+  // and be remediated, as lockfile drift.
+  function poetryFloor(output: string) {
+    const dir = mkdtempSync(join(tmpdir(), 'dxkit-locksync-py-'));
+    writeFileSync(join(dir, 'pyproject.toml'), '[tool.poetry]\nname = "fx"\n');
+    writeFileSync(join(dir, 'poetry.lock'), '');
+    try {
+      const r = runCorrectnessFloor({
+        cwd: dir,
+        changedFiles: [],
+        scope: 'full',
+        packs: [PY],
+        exec: (cmd) =>
+          cmd.bin === 'poetry' && cmd.args[0] === 'check'
+            ? { available: true, code: 1, output }
+            : { available: true, code: 0, output: '' },
+      });
+      return r.checks.find((c) => c.label === LOCKFILE_SYNC_LABEL)!;
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  it('a real drift keeps the resync remedy', () => {
+    const lock = poetryFloor(
+      'Error: pyproject.toml changed significantly since poetry.lock was last generated. ' +
+        'Run `poetry lock` to fix the lock file.',
+    );
+    expect(lock.status).toBe('fail');
+    expect(lock.output).toContain('frozen install');
+    expect(lock.output).not.toContain('manifest-validation');
+  });
+
+  it('a manifest-validation failure is disclosed as such, never as lockfile drift', () => {
+    const lock = poetryFloor('Error: Declared README file does not exist: README.md');
+    expect(lock.status).toBe('fail');
+    expect(lock.output).toContain('manifest-validation');
+    expect(lock.output).toContain('rather than re-locking');
+    expect(lock.output).not.toContain('Re-run the package manager install');
   });
 });

--- a/test/languages-contract.test.ts
+++ b/test/languages-contract.test.ts
@@ -1242,6 +1242,20 @@ describe('remediation capabilities: a provider or a reasoned exemption, per pack
       const p = declaration.provider;
       expect(p.manifestFiles.length).toBeGreaterThan(0);
       expect(p.osvEcosystem.length).toBeGreaterThan(0);
+      // A declared version grammar is deterministic, total over garbage,
+      // refuses range/wildcard shapes (never guessed), and its comparator
+      // is reflexive on an accepted version.
+      if (p.versions !== undefined) {
+        for (const bad of ['>=1.2.3', '^1.2.3', '~1.2', '1.x', '*', '', 'latest']) {
+          expect(p.versions.concrete(bad), `${lang.id}: concrete(${JSON.stringify(bad)})`).toBe(
+            false,
+          );
+          expect(p.versions.concrete(bad)).toBe(p.versions.concrete(bad));
+        }
+        for (const v of ['1.2.3', '1.2', '1.2.3.4']) {
+          if (p.versions.concrete(v)) expect(p.versions.compare(v, v)).toBe(0);
+        }
+      }
       const req = p.execution(os.tmpdir());
       expect(req.hosts.length).toBeGreaterThan(0);
       for (const t of req.toolchains) expect(Object.keys(TOOLCHAIN_DEFS)).toContain(t);

--- a/test/languages/php-remediation.test.ts
+++ b/test/languages/php-remediation.test.ts
@@ -41,6 +41,9 @@ describe('pinTransitive: the composer exact-version require pin', () => {
     expect(out.text.endsWith('\n')).toBe(true);
     expect(out.text).toContain('  "require"'); // two-space style preserved
     expect(plan.revert).toContain('guzzlehttp/psr7');
+    // The deliberate-churn disclosure rides the plan onto the ledger:
+    // composer has no scoped lock resync, and the ledger says so.
+    expect(plan.notes?.join(' ')).toContain('unrelated packages');
   });
 
   it('refuses a direct dependency (require or require-dev) and non-JSON text', () => {

--- a/test/languages/php-remediation.test.ts
+++ b/test/languages/php-remediation.test.ts
@@ -1,0 +1,89 @@
+/**
+ * The php remediation capabilities (4.4.7 V2): the composer exact-version
+ * require pin as a pure JSON transform (applied / refused / adversarial),
+ * the composer name rail, and the two reasoned exemptions (declare, lint
+ * fix) carrying real reasons. No network, no spawns.
+ */
+import { describe, it, expect } from 'vitest';
+import * as os from 'os';
+import { phpRemediation, isValidComposerPackageName } from '../../src/languages/php-remediation';
+import type { PinTransitiveProvider } from '../../src/languages/capabilities/remediation';
+
+const pin = (phpRemediation.pinTransitive as { provider: PinTransitiveProvider }).provider;
+
+const COMPOSER_JSON = `{
+  "name": "acme/app",
+  "require": {
+    "php": "^8.2",
+    "guzzlehttp/guzzle": "^7.8"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^11.0"
+  }
+}
+`;
+
+function planPin(pkg = 'guzzlehttp/psr7', version = '2.7.1') {
+  return pin.plan({ cwd: os.tmpdir(), rootDir: '', pkg, version });
+}
+
+describe('pinTransitive: the composer exact-version require pin', () => {
+  it('adds the require entry, preserving indentation and the trailing newline', () => {
+    const plan = planPin();
+    expect(plan.kind).toBe('plan');
+    if (plan.kind !== 'plan') return;
+    expect(plan.edit.file).toBe('composer.json');
+    const out = plan.edit.transform(COMPOSER_JSON);
+    if (!('text' in out)) throw new Error(out.refused);
+    const parsed = JSON.parse(out.text) as { require: Record<string, string> };
+    expect(parsed.require['guzzlehttp/psr7']).toBe('2.7.1');
+    expect(parsed.require['guzzlehttp/guzzle']).toBe('^7.8'); // untouched
+    expect(out.text.endsWith('\n')).toBe(true);
+    expect(out.text).toContain('  "require"'); // two-space style preserved
+    expect(plan.revert).toContain('guzzlehttp/psr7');
+  });
+
+  it('refuses a direct dependency (require or require-dev) and non-JSON text', () => {
+    const direct = planPin('guzzlehttp/guzzle');
+    if (direct.kind !== 'plan') throw new Error(direct.reason);
+    const d = direct.edit.transform(COMPOSER_JSON);
+    expect(d).toHaveProperty('refused');
+    if ('refused' in d) expect(d.refused).toContain('dep-bump');
+
+    const dev = planPin('phpunit/phpunit');
+    if (dev.kind !== 'plan') throw new Error(dev.reason);
+    expect(dev.edit.transform(COMPOSER_JSON)).toHaveProperty('refused');
+
+    const p = planPin();
+    if (p.kind !== 'plan') throw new Error(p.reason);
+    for (const garbage of ['', 'not a manifest {', '42', '[]']) {
+      expect(p.edit.transform(garbage)).toHaveProperty('refused');
+    }
+  });
+
+  it('refuses tokens outside the composer name/version shapes (Rule 11)', () => {
+    expect(isValidComposerPackageName('monolog/monolog')).toBe(true);
+    expect(isValidComposerPackageName('symfony/http-kernel')).toBe(true);
+    for (const bad of ['', 'monolog', '-x/y', '--flag=x/y', 'A/B', 'a b/c', 'a/b/c']) {
+      expect(isValidComposerPackageName(bad), JSON.stringify(bad)).toBe(false);
+    }
+    expect(planPin('-x/y').kind).toBe('refused');
+    expect(planPin('monolog/monolog', '3.7.0"; rm -rf /').kind).toBe('refused');
+  });
+});
+
+describe('the reasoned exemptions carry their doctrine', () => {
+  it('declareDependency: a namespace does not identify a Packagist package', () => {
+    expect(phpRemediation.declareDependency.kind).toBe('exemption');
+    if (phpRemediation.declareDependency.kind === 'exemption') {
+      expect(phpRemediation.declareDependency.reason).toContain('namespace');
+    }
+  });
+
+  it('lintFix: phpcbf cannot fix and verify in one run', () => {
+    expect(phpRemediation.lintFix.kind).toBe('exemption');
+    if (phpRemediation.lintFix.kind === 'exemption') {
+      expect(phpRemediation.lintFix.reason).toContain('phpcbf');
+    }
+  });
+});

--- a/test/languages/python-remediation.test.ts
+++ b/test/languages/python-remediation.test.ts
@@ -1,0 +1,245 @@
+/**
+ * The python remediation capabilities (4.4.7 V2): the import→distribution
+ * mapping rail, the per-manager pin plans as pure transforms on real
+ * manifest fixtures (applied / refused / adversarial), the version-probe
+ * parser total over garbage, and the per-manager install command. No
+ * network, no spawns — everything here is the pure half of the seam.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { pythonRemediation } from '../../src/languages/python-remediation';
+import { pyDistForImport } from '../../src/languages/python-dist-names';
+import type {
+  DeclareDependencyProvider,
+  PinTransitiveProvider,
+} from '../../src/languages/capabilities/remediation';
+
+const pin = (pythonRemediation.pinTransitive as { provider: PinTransitiveProvider }).provider;
+const declare = (pythonRemediation.declareDependency as { provider: DeclareDependencyProvider })
+  .provider;
+
+const cleanups: string[] = [];
+afterEach(() => {
+  for (const d of cleanups.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+});
+
+/** A temp root whose lockfile selects the manager under test. */
+function rootWith(files: Record<string, string>): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-py-remediation-'));
+  cleanups.push(dir);
+  for (const [rel, content] of Object.entries(files)) {
+    fs.writeFileSync(path.join(dir, rel), content);
+  }
+  return dir;
+}
+
+function planAt(files: Record<string, string>, pkg = 'urllib3', version = '2.5.0') {
+  return pin.plan({ cwd: rootWith(files), rootDir: '', pkg, version });
+}
+
+const UV_PYPROJECT = `[project]
+name = "fx"
+version = "0.1.0"
+dependencies = [
+    "requests>=2.31",
+]
+
+[tool.ruff]
+line-length = 100
+`;
+
+const POETRY_PYPROJECT = `[tool.poetry]
+name = "fx"
+version = "0.1.0"
+
+[tool.poetry.dependencies]
+python = "^3.11"
+requests = "^2.31"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.0"
+
+[build-system]
+requires = ["poetry-core"]
+`;
+
+const PIPFILE = `[[source]]
+url = "https://pypi.org/simple"
+name = "pypi"
+
+[packages]
+requests = "*"
+
+[dev-packages]
+pytest = "*"
+`;
+
+describe('the import → distribution mapping (one table, the declare rail)', () => {
+  it('identity for convention-named imports, alias for the known divergences', () => {
+    expect(pyDistForImport('requests')).toBe('requests');
+    expect(pyDistForImport('yaml')).toBe('pyyaml');
+    expect(pyDistForImport('PIL')).toBe('pillow');
+    // Spelling variants of one distribution fold under PEP 503.
+    expect(pyDistForImport('sklearn')).toBe('scikit-learn');
+    expect(pyDistForImport('MySQLdb')).toBe('mysqlclient');
+  });
+
+  it('refuses ambiguous aliases and injection shapes (false-negative bias)', () => {
+    expect(pyDistForImport('cv2')).toBeNull(); // three real distributions
+    expect(pyDistForImport('google')).toBeNull();
+    expect(pyDistForImport('Crypto')).toBeNull(); // pycryptodome vs pycrypto
+    for (const bad of ['', '-x', '--index-url=https://evil', 'a b', 'a\nb', './missing']) {
+      expect(pyDistForImport(bad), JSON.stringify(bad)).toBeNull();
+      expect(declare.validSpecifier(bad), JSON.stringify(bad)).toBe(false);
+    }
+  });
+});
+
+describe('pinTransitive: the uv override surface', () => {
+  it('appends [tool.uv] override-dependencies when no section exists, preserving the manifest', () => {
+    const plan = planAt({ 'uv.lock': '', 'pyproject.toml': UV_PYPROJECT });
+    expect(plan.kind).toBe('plan');
+    if (plan.kind !== 'plan') return;
+    expect(plan.edit.file).toBe('pyproject.toml');
+    const out = plan.edit.transform(UV_PYPROJECT);
+    expect('text' in out).toBe(true);
+    if (!('text' in out)) return;
+    expect(out.text.startsWith(UV_PYPROJECT)).toBe(true);
+    expect(out.text).toContain('[tool.uv]\noverride-dependencies = ["urllib3==2.5.0"]');
+    expect(plan.revert).toContain('override-dependencies');
+  });
+
+  it('inserts into an existing [tool.uv] section instead of forking a second one', () => {
+    const text = `${UV_PYPROJECT}\n[tool.uv]\ndev-dependencies = []\n`;
+    const plan = planAt({ 'uv.lock': '', 'pyproject.toml': text });
+    if (plan.kind !== 'plan') throw new Error(plan.reason);
+    const out = plan.edit.transform(text);
+    if (!('text' in out)) throw new Error(out.refused);
+    expect(out.text.match(/\[tool\.uv\]/g)).toHaveLength(1);
+    expect(out.text).toContain('[tool.uv]\noverride-dependencies = ["urllib3==2.5.0"]');
+  });
+
+  it('refuses a direct dependency, an existing override list, and garbage', () => {
+    const plan = planAt({ 'uv.lock': '', 'pyproject.toml': UV_PYPROJECT }, 'requests', '2.32.0');
+    if (plan.kind !== 'plan') throw new Error(plan.reason);
+    const direct = plan.edit.transform(UV_PYPROJECT);
+    expect(direct).toHaveProperty('refused');
+    if ('refused' in direct) expect(direct.refused).toContain('dep-bump');
+
+    const withOverride = `${UV_PYPROJECT}\n[tool.uv]\noverride-dependencies = ["x==1.0"]\n`;
+    const p2 = planAt({ 'uv.lock': '', 'pyproject.toml': withOverride });
+    if (p2.kind !== 'plan') throw new Error(p2.reason);
+    expect(p2.edit.transform(withOverride)).toHaveProperty('refused');
+
+    for (const garbage of ['', 'not a manifest {', '42']) {
+      const out = p2.edit.transform(garbage);
+      expect(out).toHaveProperty('refused');
+    }
+  });
+});
+
+describe('pinTransitive: the poetry + pipenv explicit-entry pins', () => {
+  it('poetry: inserts the exact pin under [tool.poetry.dependencies]', () => {
+    const plan = planAt({ 'poetry.lock': '', 'pyproject.toml': POETRY_PYPROJECT });
+    if (plan.kind !== 'plan') throw new Error(plan.reason);
+    const out = plan.edit.transform(POETRY_PYPROJECT);
+    if (!('text' in out)) throw new Error(out.refused);
+    expect(out.text).toContain('[tool.poetry.dependencies]\nurllib3 = "2.5.0"');
+    expect(plan.revert).toContain('tool.poetry.dependencies');
+  });
+
+  it('poetry: refuses a direct dependency (main or group) and a table-less layout', () => {
+    const plan = planAt({ 'poetry.lock': '', 'pyproject.toml': POETRY_PYPROJECT }, 'requests');
+    if (plan.kind !== 'plan') throw new Error(plan.reason);
+    expect(plan.edit.transform(POETRY_PYPROJECT)).toHaveProperty('refused');
+
+    const dev = planAt({ 'poetry.lock': '', 'pyproject.toml': POETRY_PYPROJECT }, 'pytest');
+    if (dev.kind !== 'plan') throw new Error(dev.reason);
+    expect(dev.edit.transform(POETRY_PYPROJECT)).toHaveProperty('refused');
+
+    const pep621 = '[project]\nname = "fx"\ndependencies = []\n';
+    const p = planAt({ 'poetry.lock': '', 'pyproject.toml': pep621 });
+    if (p.kind !== 'plan') throw new Error(p.reason);
+    const out = p.edit.transform(pep621);
+    expect(out).toHaveProperty('refused');
+    if ('refused' in out) expect(out.refused).toContain('[tool.poetry.dependencies]');
+  });
+
+  it('pipenv: inserts the ==pin under [packages], refuses direct entries either section', () => {
+    const plan = planAt({ 'Pipfile.lock': '', Pipfile: PIPFILE });
+    if (plan.kind !== 'plan') throw new Error(plan.reason);
+    expect(plan.edit.file).toBe('Pipfile');
+    const out = plan.edit.transform(PIPFILE);
+    if (!('text' in out)) throw new Error(out.refused);
+    expect(out.text).toContain('[packages]\nurllib3 = "==2.5.0"');
+
+    const direct = planAt({ 'Pipfile.lock': '', Pipfile: PIPFILE }, 'requests');
+    if (direct.kind !== 'plan') throw new Error(direct.reason);
+    expect(direct.edit.transform(PIPFILE)).toHaveProperty('refused');
+    const dev = planAt({ 'Pipfile.lock': '', Pipfile: PIPFILE }, 'pytest');
+    if (dev.kind !== 'plan') throw new Error(dev.reason);
+    expect(dev.edit.transform(PIPFILE)).toHaveProperty('refused');
+  });
+
+  it('refuses a requirements-only root, an empty root, and injection-shaped tokens', () => {
+    const reqs = planAt({ 'requirements.txt': 'requests==2.31.0\n' });
+    expect(reqs.kind).toBe('refused');
+    if (reqs.kind === 'refused') expect(reqs.reason).toContain('agent tier');
+
+    expect(planAt({}).kind).toBe('refused');
+
+    const badPkg = planAt({ 'uv.lock': '', 'pyproject.toml': UV_PYPROJECT }, '-x', '1.0.0');
+    expect(badPkg.kind).toBe('refused');
+    const badVersion = planAt(
+      { 'uv.lock': '', 'pyproject.toml': UV_PYPROJECT },
+      'urllib3',
+      '1.0"; rm -rf /',
+    );
+    expect(badVersion.kind).toBe('refused');
+  });
+});
+
+describe('declareDependency: probe parsing and the per-manager install command', () => {
+  it('parses pip index versions output (header line, then the fallback list), null on garbage', () => {
+    expect(
+      declare.parseProbeOutput(
+        'WARNING: pip index is currently an experimental command.\n' +
+          'requests (2.32.5)\nAvailable versions: 2.32.5, 2.32.4\n',
+      ),
+    ).toBe('2.32.5');
+    expect(declare.parseProbeOutput('Available versions: 6.0.2, 6.0.1\n')).toBe('6.0.2');
+    for (const garbage of ['', 'npm error 404', '\n\n', 'not-a-version']) {
+      expect(declare.parseProbeOutput(garbage)).toBeNull();
+    }
+  });
+
+  it('probes the DISTRIBUTION the alias table names, never the raw import', () => {
+    const probe = declare.versionProbe({ cwd: os.tmpdir(), rootDir: '', specifier: 'yaml' });
+    expect(probe).toEqual({ bin: 'pip', args: ['index', 'versions', 'pyyaml'] });
+  });
+
+  it('the install command follows the owning root strategy manager, dev section included', () => {
+    const ctx = { rootDir: '', specifier: 'yaml', version: '6.0.2', dev: false };
+    const uv = rootWith({ 'uv.lock': '', 'pyproject.toml': UV_PYPROJECT });
+    expect(declare.installCommand({ ...ctx, cwd: uv })).toEqual({
+      bin: 'uv',
+      args: ['add', 'pyyaml==6.0.2'],
+    });
+    expect(declare.installCommand({ ...ctx, cwd: uv, dev: true })).toEqual({
+      bin: 'uv',
+      args: ['add', '--dev', 'pyyaml==6.0.2'],
+    });
+    const poetry = rootWith({ 'poetry.lock': '', 'pyproject.toml': POETRY_PYPROJECT });
+    expect(declare.installCommand({ ...ctx, cwd: poetry, dev: true })).toEqual({
+      bin: 'poetry',
+      args: ['add', '--group', 'dev', 'pyyaml==6.0.2'],
+    });
+    const pipenv = rootWith({ 'Pipfile.lock': '', Pipfile: PIPFILE });
+    expect(declare.installCommand({ ...ctx, cwd: pipenv })).toEqual({
+      bin: 'pipenv',
+      args: ['install', 'pyyaml==6.0.2'],
+    });
+  });
+});

--- a/test/languages/python-remediation.test.ts
+++ b/test/languages/python-remediation.test.ts
@@ -3,7 +3,7 @@
  * mapping rail, the per-manager pin plans as pure transforms on real
  * manifest fixtures (applied / refused / adversarial), the version-probe
  * parser total over garbage, and the per-manager install command. No
- * network, no spawns — everything here is the pure half of the seam.
+ * network, no spawns: everything here is the pure half of the seam.
  */
 import { describe, it, expect, afterEach } from 'vitest';
 import * as fs from 'fs';
@@ -87,9 +87,11 @@ describe('the import → distribution mapping (one table, the declare rail)', ()
   });
 
   it('refuses ambiguous aliases and injection shapes (false-negative bias)', () => {
-    expect(pyDistForImport('cv2')).toBeNull(); // three real distributions
+    expect(pyDistForImport('cv2')).toBeNull(); // two real distributions
     expect(pyDistForImport('google')).toBeNull();
     expect(pyDistForImport('Crypto')).toBeNull(); // pycryptodome vs pycrypto
+    expect(pyDistForImport('psycopg2')).toBeNull(); // the source dist vs -binary
+    expect(pyDistForImport('snowflake')).toBeNull(); // connector vs snowpark
     for (const bad of ['', '-x', '--index-url=https://evil', 'a b', 'a\nb', './missing']) {
       expect(pyDistForImport(bad), JSON.stringify(bad)).toBeNull();
       expect(declare.validSpecifier(bad), JSON.stringify(bad)).toBe(false);
@@ -146,7 +148,7 @@ describe('pinTransitive: the poetry + pipenv explicit-entry pins', () => {
     if (plan.kind !== 'plan') throw new Error(plan.reason);
     const out = plan.edit.transform(POETRY_PYPROJECT);
     if (!('text' in out)) throw new Error(out.refused);
-    expect(out.text).toContain('[tool.poetry.dependencies]\nurllib3 = "2.5.0"');
+    expect(out.text).toContain('[tool.poetry.dependencies]\n"urllib3" = "2.5.0"');
     expect(plan.revert).toContain('tool.poetry.dependencies');
   });
 
@@ -173,7 +175,7 @@ describe('pinTransitive: the poetry + pipenv explicit-entry pins', () => {
     expect(plan.edit.file).toBe('Pipfile');
     const out = plan.edit.transform(PIPFILE);
     if (!('text' in out)) throw new Error(out.refused);
-    expect(out.text).toContain('[packages]\nurllib3 = "==2.5.0"');
+    expect(out.text).toContain('[packages]\n"urllib3" = "==2.5.0"');
 
     const direct = planAt({ 'Pipfile.lock': '', Pipfile: PIPFILE }, 'requests');
     if (direct.kind !== 'plan') throw new Error(direct.reason);
@@ -181,6 +183,47 @@ describe('pinTransitive: the poetry + pipenv explicit-entry pins', () => {
     const dev = planAt({ 'Pipfile.lock': '', Pipfile: PIPFILE }, 'pytest');
     if (dev.kind !== 'plan') throw new Error(dev.reason);
     expect(dev.edit.transform(PIPFILE)).toHaveProperty('refused');
+  });
+
+  it('quotes dotted names always, so a dotted pin never parses as a dotted TOML key', () => {
+    const applied = planAt(
+      { 'poetry.lock': '', 'pyproject.toml': POETRY_PYPROJECT },
+      'zope.interface',
+      '6.4.1',
+    );
+    if (applied.kind !== 'plan') throw new Error(applied.reason);
+    const out = applied.edit.transform(POETRY_PYPROJECT);
+    if (!('text' in out)) throw new Error(out.refused);
+    expect(out.text).toContain('[tool.poetry.dependencies]\n"zope.interface" = "6.4.1"');
+
+    // A dotted DIRECT dependency still refuses, whichever quoting the
+    // manifest used for its key.
+    const dotted = POETRY_PYPROJECT.replace(
+      'requests = "^2.31"',
+      'requests = "^2.31"\n"ruamel.yaml" = "^0.18"',
+    );
+    const direct = planAt({ 'poetry.lock': '', 'pyproject.toml': dotted }, 'ruamel.yaml');
+    if (direct.kind !== 'plan') throw new Error(direct.reason);
+    expect(direct.edit.transform(dotted)).toHaveProperty('refused');
+
+    const pipenv = planAt({ 'Pipfile.lock': '', Pipfile: PIPFILE }, 'ruamel.yaml', '0.18.6');
+    if (pipenv.kind !== 'plan') throw new Error(pipenv.reason);
+    const pout = pipenv.edit.transform(PIPFILE);
+    if (!('text' in pout)) throw new Error(pout.refused);
+    expect(pout.text).toContain('[packages]\n"ruamel.yaml" = "==0.18.6"');
+    const pipfileDotted = PIPFILE.replace('requests = "*"', 'requests = "*"\n"ruamel.yaml" = "*"');
+    const pdirect = planAt({ 'Pipfile.lock': '', Pipfile: pipfileDotted }, 'ruamel.yaml');
+    if (pdirect.kind !== 'plan') throw new Error(pdirect.reason);
+    expect(pdirect.edit.transform(pipfileDotted)).toHaveProperty('refused');
+  });
+
+  it('uv: a PEP 735 [dependency-groups] entry is a direct dependency too (what uv add --dev writes)', () => {
+    const withGroups = UV_PYPROJECT + '\n[dependency-groups]\ndev = [\n    "pytest>=8.0",\n]\n';
+    const plan = planAt({ 'uv.lock': '', 'pyproject.toml': withGroups }, 'pytest', '8.3.0');
+    if (plan.kind !== 'plan') throw new Error(plan.reason);
+    const out = plan.edit.transform(withGroups);
+    expect(out).toHaveProperty('refused');
+    if ('refused' in out) expect(out.refused).toContain('direct dependency');
   });
 
   it('refuses a requirements-only root, an empty root, and injection-shaped tokens', () => {
@@ -201,6 +244,34 @@ describe('pinTransitive: the poetry + pipenv explicit-entry pins', () => {
   });
 });
 
+describe('the python pin-version grammar (PEP 440 releases, 2-segment included)', () => {
+  const scheme = pin.versions!;
+  it('accepts plain releases of any segment count; refuses ranges and unorderable markers', () => {
+    for (const ok of ['2.31', '2.5.0', '1.26.19', '4', '1.2.3.4']) {
+      expect(scheme.concrete(ok), ok).toBe(true);
+    }
+    for (const bad of [
+      '>=2.5',
+      '^2.5.0',
+      '~2.5',
+      '2.*',
+      '*',
+      '2.31.post1',
+      '2.31rc1',
+      '1!2.0',
+      '2.5.0+local',
+      '',
+    ]) {
+      expect(scheme.concrete(bad), bad).toBe(false);
+    }
+  });
+  it('orders numerically, missing segments as zero', () => {
+    expect(scheme.compare('2.31', '2.9')).toBeGreaterThan(0);
+    expect(scheme.compare('2.31', '2.31.0')).toBe(0);
+    expect(scheme.compare('2.30.1', '2.31')).toBeLessThan(0);
+  });
+});
+
 describe('declareDependency: probe parsing and the per-manager install command', () => {
   it('parses pip index versions output (header line, then the fallback list), null on garbage', () => {
     expect(
@@ -218,6 +289,33 @@ describe('declareDependency: probe parsing and the per-manager install command',
   it('probes the DISTRIBUTION the alias table names, never the raw import', () => {
     const probe = declare.versionProbe({ cwd: os.tmpdir(), rootDir: '', specifier: 'yaml' });
     expect(probe).toEqual({ bin: 'pip', args: ['index', 'versions', 'pyyaml'] });
+  });
+
+  it('probes through uv itself on a uv-managed root (uv venvs ship without pip), pip elsewhere', () => {
+    const uvRoot = rootWith({ 'uv.lock': '', 'pyproject.toml': UV_PYPROJECT });
+    expect(declare.versionProbe({ cwd: uvRoot, rootDir: '', specifier: 'yaml' })).toEqual({
+      bin: 'uv',
+      args: ['pip', 'install', '--dry-run', '--no-deps', 'pyyaml'],
+    });
+    const poetryRoot = rootWith({ 'poetry.lock': '', 'pyproject.toml': POETRY_PYPROJECT });
+    expect(declare.versionProbe({ cwd: poetryRoot, rootDir: '', specifier: 'yaml' })).toEqual({
+      bin: 'pip',
+      args: ['index', 'versions', 'pyyaml'],
+    });
+    // uv's dry-run output parses through the same total parser.
+    expect(
+      declare.parseProbeOutput(
+        'Resolved 1 package in 49ms\nWould install 1 package\n + pyyaml==6.0.2\n',
+      ),
+    ).toBe('6.0.2');
+    // uv without a provisioned venv is an environment fact, never a
+    // verdict on the specifier.
+    expect(
+      declare.probeInfrastructure!(
+        'error: No virtual environment found; run `uv venv` to create an environment',
+      ),
+    ).toBe(true);
+    expect(declare.probeInfrastructure!('requirements are unsatisfiable')).toBe(false);
   });
 
   it('the install command follows the owning root strategy manager, dev section included', () => {

--- a/test/languages/ruby-remediation.test.ts
+++ b/test/languages/ruby-remediation.test.ts
@@ -1,0 +1,158 @@
+/**
+ * The ruby remediation capabilities (4.4.7 V2): the Gemfile explicit-entry
+ * pin as a pure transform (applied / refused / adversarial), the gem-name
+ * rail, the `gem search` probe parser total over garbage, the bundle add
+ * install command, and the rubocop fix-mode parser dropping corrected
+ * offenses. No network, no spawns.
+ */
+import { describe, it, expect } from 'vitest';
+import * as os from 'os';
+import { rubyRemediation, isValidGemName } from '../../src/languages/ruby-remediation';
+import { parseRubocopFixJson, parseRubocopJson } from '../../src/languages/ruby';
+import type {
+  DeclareDependencyProvider,
+  PinTransitiveProvider,
+} from '../../src/languages/capabilities/remediation';
+
+const pin = (rubyRemediation.pinTransitive as { provider: PinTransitiveProvider }).provider;
+const declare = (rubyRemediation.declareDependency as { provider: DeclareDependencyProvider })
+  .provider;
+
+const GEMFILE = `source "https://rubygems.org"
+
+ruby "3.3.0"
+
+gem "rails", "~> 7.1"
+gem 'pg'
+
+group :development, :test do
+  gem "rspec-rails"
+end
+`;
+
+function planPin(pkg = 'rack', version = '2.2.9') {
+  return pin.plan({ cwd: os.tmpdir(), rootDir: '', pkg, version });
+}
+
+describe('pinTransitive: the Gemfile explicit-entry pin', () => {
+  it('appends the exact-version gem line at the top level, preserving the Gemfile', () => {
+    const plan = planPin();
+    expect(plan.kind).toBe('plan');
+    if (plan.kind !== 'plan') return;
+    expect(plan.edit.file).toBe('Gemfile');
+    const out = plan.edit.transform(GEMFILE);
+    if (!('text' in out)) throw new Error(out.refused);
+    expect(out.text.startsWith(GEMFILE)).toBe(true);
+    expect(out.text).toContain('gem "rack", "2.2.9"');
+    expect(out.text).toContain('Pins a transitive dependency');
+    expect(plan.revert).toContain('rack');
+  });
+
+  it('refuses a directly declared gem (either quote style) and non-Gemfile text', () => {
+    const doubleQuoted = planPin('rails');
+    if (doubleQuoted.kind !== 'plan') throw new Error(doubleQuoted.reason);
+    const d = doubleQuoted.edit.transform(GEMFILE);
+    expect(d).toHaveProperty('refused');
+    if ('refused' in d) expect(d.refused).toContain('dep-bump');
+
+    const singleQuoted = planPin('pg');
+    if (singleQuoted.kind !== 'plan') throw new Error(singleQuoted.reason);
+    expect(singleQuoted.edit.transform(GEMFILE)).toHaveProperty('refused');
+
+    // A group-declared gem is still declared.
+    const grouped = planPin('rspec-rails');
+    if (grouped.kind !== 'plan') throw new Error(grouped.reason);
+    expect(grouped.edit.transform(GEMFILE)).toHaveProperty('refused');
+
+    for (const garbage of ['', 'not a manifest {', '42']) {
+      const p = planPin();
+      if (p.kind !== 'plan') throw new Error(p.reason);
+      expect(p.edit.transform(garbage)).toHaveProperty('refused');
+    }
+  });
+
+  it('refuses injection-shaped tokens before any edit exists (Rule 11)', () => {
+    expect(planPin('-x').kind).toBe('refused');
+    expect(planPin('a b').kind).toBe('refused');
+    expect(planPin('rack', '2.2.9"; system "id').kind).toBe('refused');
+  });
+});
+
+describe('declareDependency: the gem rail, probe parsing, bundle add', () => {
+  it('the rail rejects flag shapes and nested require paths', () => {
+    expect(isValidGemName('nokogiri')).toBe(true);
+    expect(isValidGemName('rspec-rails')).toBe(true);
+    for (const bad of [
+      '',
+      '-x',
+      '--source=https://evil',
+      'a b',
+      'a\nb',
+      'active_support/core_ext',
+    ]) {
+      expect(declare.validSpecifier(bad), JSON.stringify(bad)).toBe(false);
+    }
+  });
+
+  it('parses gem search --remote --exact output, platform variants included; null on garbage', () => {
+    expect(declare.parseProbeOutput('\n*** REMOTE GEMS ***\n\nnokogiri (1.16.5)\n')).toBe('1.16.5');
+    expect(declare.parseProbeOutput('nokogiri (1.16.5 ruby java, 1.16.4)\n')).toBe('1.16.5');
+    for (const garbage of ['', 'npm error 404', '\n\n', 'not-a-version']) {
+      expect(declare.parseProbeOutput(garbage)).toBeNull();
+    }
+  });
+
+  it('bundle add carries the exact version, and test-only importers land in :development', () => {
+    const ctx = { cwd: os.tmpdir(), rootDir: '', specifier: 'nokogiri', version: '1.16.5' };
+    expect(declare.installCommand({ ...ctx, dev: false })).toEqual({
+      bin: 'bundle',
+      args: ['add', 'nokogiri', '--version', '1.16.5'],
+    });
+    expect(declare.installCommand({ ...ctx, dev: true })).toEqual({
+      bin: 'bundle',
+      args: ['add', 'nokogiri', '--version', '1.16.5', '--group', 'development'],
+    });
+  });
+});
+
+describe('the rubocop fix-mode parser (corrected offenses are not leftovers)', () => {
+  const sample = JSON.stringify({
+    files: [
+      {
+        path: 'app/models/user.rb',
+        offenses: [
+          {
+            cop_name: 'Layout/TrailingWhitespace',
+            message: 'Trailing whitespace detected.',
+            corrected: true,
+            location: { line: 3 },
+          },
+          {
+            cop_name: 'Lint/UselessAssignment',
+            message: 'Useless assignment to variable - x.',
+            corrected: false,
+            location: { line: 9 },
+          },
+        ],
+      },
+    ],
+  });
+
+  it('drops corrected offenses in fix mode; the gate parser keeps reporting them', () => {
+    expect(parseRubocopFixJson(sample)).toEqual([
+      {
+        file: 'app/models/user.rb',
+        line: 9,
+        rule: 'Lint/UselessAssignment',
+        message: 'Useless assignment to variable - x.',
+      },
+    ]);
+    expect(parseRubocopJson(sample)).toHaveLength(2);
+  });
+
+  it('is total over garbage', () => {
+    for (const garbage of ['', 'not json', '{"files": 42}']) {
+      expect(parseRubocopFixJson(garbage)).toEqual([]);
+    }
+  });
+});

--- a/test/languages/ruby-remediation.test.ts
+++ b/test/languages/ruby-remediation.test.ts
@@ -78,6 +78,23 @@ describe('pinTransitive: the Gemfile explicit-entry pin', () => {
   });
 });
 
+describe('the ruby pin-version grammar (RubyGems 4-segment security releases)', () => {
+  const scheme = pin.versions!;
+  it('accepts up to five numeric segments (7.0.8.7, the rails-family fix shape); refuses ranges and prereleases', () => {
+    for (const ok of ['1.16.5', '7.0.8.7', '6.1.7.10', '3.2']) {
+      expect(scheme.concrete(ok), ok).toBe(true);
+    }
+    for (const bad of ['>= 7.0.8', '~> 7.0', '7.0.8.rc1', '7.x', '*', '']) {
+      expect(scheme.concrete(bad), bad).toBe(false);
+    }
+  });
+  it('orders numerically, never lexicographically (6.1.7.10 outranks 6.1.7.9)', () => {
+    expect(scheme.compare('6.1.7.10', '6.1.7.9')).toBeGreaterThan(0);
+    expect(scheme.compare('7.0.8', '7.0.8.7')).toBeLessThan(0);
+    expect(scheme.compare('7.0.8.7', '7.0.8.7')).toBe(0);
+  });
+});
+
 describe('declareDependency: the gem rail, probe parsing, bundle add', () => {
   it('the rail rejects flag shapes and nested require paths', () => {
     expect(isValidGemName('nokogiri')).toBe(true);

--- a/test/remediate/e2e-rethink.test.ts
+++ b/test/remediate/e2e-rethink.test.ts
@@ -209,6 +209,8 @@ const offlineLedgerExec: OrderLedgerExec = () => {
 interface EstateRun {
   readonly repo: string;
   readonly taskId: string;
+  /** The active packs (defaults to the node estate's typescript pack). */
+  readonly packs?: typeof TS_PACKS;
   readonly driver: ReturnType<typeof stubDriver>['driver'];
   readonly entryFloor?: CorrectnessFloorResult;
   readonly scan?: DepVulnFinding[];
@@ -228,6 +230,7 @@ interface EstateRun {
  *  real-ledger scenario overrides it deliberately. */
 async function runOnEstate(o: EstateRun): Promise<RemediateResult> {
   const exec = o.exec ?? lockWritingExec(o.repo);
+  const packs = o.packs ?? TS_PACKS;
   const opts: RemediateRunOptions = {
     cwd: o.repo,
     trust: trustedLocalContext(),
@@ -247,7 +250,7 @@ async function runOnEstate(o: EstateRun): Promise<RemediateResult> {
     ...(o.explicitDispatch ? { explicitDispatch: true } : {}),
     // The frame's invariant step runs the REAL collector over the real
     // node pack on the estate; only the package manager is faked.
-    frameInvariants: { packs: TS_PACKS, exec: (o.frameExec ?? exec).exec },
+    frameInvariants: { packs, exec: (o.frameExec ?? exec).exec },
     runRecipePhase: (phase: RecipePhaseOptions) =>
       runRecipePhaseForTask({
         ...phase,
@@ -256,7 +259,7 @@ async function runOnEstate(o: EstateRun): Promise<RemediateResult> {
         queryOsv: async () => [],
         auditDepVulns: async () => [],
         gather: {
-          packs: TS_PACKS,
+          packs,
           scanDepVulns: async () => o.scan ?? [],
           now: NOW,
           history: [],
@@ -339,6 +342,130 @@ describe('e2e a: a recipe-only plan lands verified at $0', () => {
     expect(exec.calls.some((c) => c.cmd.bin === 'npm')).toBe(true);
     expect(git(repo, ['log', '--oneline'])).toContain('lockfile-sync recipe');
     expect(r.ledger).toContain('stale-lockfile:typescript');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// a2. The recipe tier is language-parametric (4.4.7 V2): the same recipe-only
+//     $0 landing on a NON-JS repo, the matrix discipline (a fix that only
+//     works for one stack fails here). The driver still throws on contact.
+// ---------------------------------------------------------------------------
+
+const PY_PACKS = [getLanguage('python')!];
+
+const PY_PYPROJECT = `[project]
+name = "fixture"
+version = "1.0.0"
+dependencies = [
+    "requests>=2.31",
+]
+`;
+
+/** A python (uv) estate: pyproject + uv.lock, remediate enabled, the same
+ *  committed baseline + deferred allowlist shape as the node estate. */
+function pyEstate(): string {
+  return fixtureRepo({
+    'pyproject.toml': PY_PYPROJECT,
+    'uv.lock': 'version = 1\n',
+    'app.py': 'print("hello")\n',
+    '.dxkit/policy.json': policyJson(),
+    '.dxkit/baselines/main.json': baselineJson(),
+    '.dxkit/allowlist.json': DEFERRED_ALLOWLIST,
+  });
+}
+
+/** The python estate's exec fake: `uv sync` (the pack's declared resync)
+ *  rewrites the lockfile; `uv lock --check` (the declared sync check)
+ *  passes cleanly. */
+function uvLockWritingExec(repo: string): ReturnType<typeof fakeExec> {
+  return fakeExec((cmd, execCwd) => {
+    if (cmd.bin === 'uv' && cmd.args[0] === 'sync') {
+      fs.appendFileSync(path.join(execCwd ?? repo, 'uv.lock'), '\n');
+    }
+  });
+}
+
+describe('e2e a2: a recipe-only plan lands verified at $0 on a python repo', () => {
+  it('deferred advisory with a fixed version: the uv override pin applies, resyncs, commits; the driver is never touched', async () => {
+    const repo = pyEstate();
+    const { driver, runs } = stubDriver(); // throws on contact
+    const exec = uvLockWritingExec(repo);
+    const r = await runOnEstate({
+      repo,
+      packs: PY_PACKS,
+      taskId: 'fix-vulns',
+      driver,
+      exec,
+      scan: [
+        {
+          id: 'GHSA-py',
+          package: 'urllib3',
+          installedVersion: '2.0.7',
+          tool: 'osv-scanner',
+          packId: 'python',
+          severity: 'high',
+          reachable: true,
+          fingerprint: 'dead000011112222',
+          fixedVersion: '2.5.0',
+        },
+      ],
+    });
+
+    expect(runs).toHaveLength(0);
+    expect(r.outcome).toBe('verified');
+    expect(r.recipes?.records.map((rec) => [rec.orderId, rec.outcome.kind])).toEqual([
+      ['dep-advisory:urllib3', 'applied'],
+    ]);
+    expect(r.envelope).toBeUndefined(); // nothing was spent
+    // The fix is REAL: the override landed in pyproject.toml in a commit
+    // made by the recipe, and the resync ran through uv, never npm.
+    const manifest = git(repo, ['show', 'HEAD:pyproject.toml']);
+    expect(manifest).toContain('[tool.uv]');
+    expect(manifest).toContain('override-dependencies = ["urllib3==2.5.0"]');
+    expect(exec.calls.some((c) => c.cmd.bin === 'uv' && c.cmd.args[0] === 'sync')).toBe(true);
+    expect(exec.calls.every((c) => c.cmd.bin !== 'npm')).toBe(true);
+    expect(git(repo, ['log', '--oneline'])).toContain('override-pin recipe');
+  });
+
+  it('stale uv lockfile: lockfile-sync resyncs with uv, verifies with the pack sync check, commits; zero driver invocations', async () => {
+    const repo = pyEstate();
+    const { driver, runs } = stubDriver();
+    const staleEntry: CorrectnessFloorResult = {
+      ran: true,
+      blocks: true,
+      checks: [
+        {
+          pack: 'python',
+          label: LOCKFILE_SYNC_LABEL,
+          bin: 'uv',
+          args: ['lock', '--check'],
+          status: 'fail',
+          output: 'The lockfile at `uv.lock` needs to be updated',
+        },
+      ],
+    };
+    const exec = uvLockWritingExec(repo);
+    const r = await runOnEstate({
+      repo,
+      packs: PY_PACKS,
+      taskId: 'fix-build',
+      driver,
+      entryFloor: staleEntry,
+      exec,
+    });
+
+    expect(runs).toHaveLength(0);
+    expect(r.outcome).toBe('verified');
+    expect(r.recipes?.records.map((rec) => [rec.orderId, rec.outcome.kind])).toEqual([
+      ['stale-lockfile:python', 'applied'],
+    ]);
+    // The resync AND the verify both went through the python pack's
+    // declared commands (uv sync, then uv lock --check).
+    const uvCalls = exec.calls.filter((c) => c.cmd.bin === 'uv').map((c) => c.cmd.args[0]);
+    expect(uvCalls).toContain('sync');
+    expect(uvCalls).toContain('lock');
+    expect(git(repo, ['log', '--oneline'])).toContain('lockfile-sync recipe');
+    expect(r.ledger).toContain('stale-lockfile:python');
   });
 });
 

--- a/test/remediate/recipes/declare-dependency.test.ts
+++ b/test/remediate/recipes/declare-dependency.test.ts
@@ -191,15 +191,63 @@ describe('declare-dependency recipe', () => {
     if (outcome.kind === 'refused') expect(outcome.reason).toContain('no-such-pkg');
   });
 
-  it('refuses orders from packs other than typescript this round', async () => {
+  it('refuses orders from a pack whose declaration is an exemption, with the declared reason', async () => {
     const cwd = repoImporting('left-pad');
     const { exec } = fakeExec();
     const outcome = await executeDeclareDependency(
-      importOrder('requests', ['app.py'], 'python'),
+      importOrder('github.com/x/y', ['main.go'], 'go'),
       makeCtx(cwd, { exec }),
     );
     expect(outcome.kind).toBe('refused');
-    if (outcome.kind === 'refused') expect(outcome.reason).toContain('python');
+    if (outcome.kind === 'refused') expect(outcome.reason).toContain('go');
+  });
+
+  it('applies on a python root: the alias-mapped distribution resolves, uv adds it, the resolution check confirms', async () => {
+    // `import yaml` in a uv-managed root: the probe and install must target
+    // the DISTRIBUTION (pyyaml), and the verify is the python pack's own
+    // resolution check reading the declared manifest after the install.
+    const cwd = tempRepo({
+      'pyproject.toml': '[project]\nname = "fx"\nversion = "0.1.0"\ndependencies = []\n',
+      'uv.lock': 'version = 1\n',
+      'app.py': 'import yaml\n',
+      // A provisioned project venv: the resolution check declines without
+      // one, and the declared-manifest read is what confirms the install.
+      '.venv/lib/python3.12/site-packages/.keep': '',
+    });
+    const { exec, calls } = fakeExec((cmd) => {
+      if (cmd.bin === 'pip' && cmd.args[0] === 'index') {
+        return { output: 'pyyaml (6.0.2)\nAvailable versions: 6.0.2, 6.0.1\n' };
+      }
+      if (cmd.bin === 'uv' && cmd.args[0] === 'add') {
+        fs.writeFileSync(
+          path.join(cwd, 'pyproject.toml'),
+          '[project]\nname = "fx"\nversion = "0.1.0"\ndependencies = ["pyyaml==6.0.2"]\n',
+        );
+      }
+      return undefined;
+    });
+    const order = makeOrder({
+      id: 'unresolved-import:python:.',
+      class: 'unresolved-import',
+      findings: [
+        floorFinding('python/import-resolution#yaml', 'python', 'import-resolution', {
+          specifier: 'yaml',
+          importingFiles: ['app.py'],
+        }),
+      ],
+      envelope: { paths: ['app.py', 'pyproject.toml', 'uv.lock'], manifests: true },
+      constraints: { install: { bin: 'uv', args: ['sync', '--locked'] }, forbidden: [] },
+    });
+    const outcome = await executeDeclareDependency(order, makeCtx(cwd, { exec }));
+    expect(outcome).toEqual({
+      kind: 'applied',
+      changedFiles: ['pyproject.toml', 'uv.lock'],
+    });
+    // Probe and install both name the distribution, never the import.
+    expect(calls.map((c) => [c.cmd.bin, ...c.cmd.args].join(' '))).toEqual([
+      'pip index versions pyyaml',
+      'uv add pyyaml==6.0.2',
+    ]);
   });
 
   it('fails verify when the specifier still does not resolve after the install', async () => {

--- a/test/remediate/recipes/declare-dependency.test.ts
+++ b/test/remediate/recipes/declare-dependency.test.ts
@@ -215,8 +215,10 @@ describe('declare-dependency recipe', () => {
       '.venv/lib/python3.12/site-packages/.keep': '',
     });
     const { exec, calls } = fakeExec((cmd) => {
-      if (cmd.bin === 'pip' && cmd.args[0] === 'index') {
-        return { output: 'pyyaml (6.0.2)\nAvailable versions: 6.0.2, 6.0.1\n' };
+      if (cmd.bin === 'uv' && cmd.args[0] === 'pip') {
+        return {
+          output: 'Resolved 1 package in 49ms\nWould install 1 package\n + pyyaml==6.0.2\n',
+        };
       }
       if (cmd.bin === 'uv' && cmd.args[0] === 'add') {
         fs.writeFileSync(
@@ -243,11 +245,69 @@ describe('declare-dependency recipe', () => {
       kind: 'applied',
       changedFiles: ['pyproject.toml', 'uv.lock'],
     });
-    // Probe and install both name the distribution, never the import.
+    // Probe and install both name the distribution, never the import, and
+    // a uv root probes through uv itself (its venvs ship without pip).
     expect(calls.map((c) => [c.cmd.bin, ...c.cmd.args].join(' '))).toEqual([
-      'pip index versions pyyaml',
+      'uv pip install --dry-run --no-deps pyyaml',
       'uv add pyyaml==6.0.2',
     ]);
+  });
+
+  it('an infrastructure-shaped probe failure is a named failure, never a typo refusal', async () => {
+    // An old pip without the `index` subcommand: the specifier gets no
+    // verdict, the order stays open for the agent tier.
+    const cwd = repoImporting('left-pad');
+    const { exec } = fakeExec((cmd) => {
+      if (cmd.args[0] === 'view') {
+        return { code: 1, output: 'ERROR: unknown command "index"' };
+      }
+      return undefined;
+    });
+    const outcome = await executeDeclareDependency(
+      importOrder('left-pad', ['src/a.ts']),
+      makeCtx(cwd, { exec }),
+    );
+    expect(outcome.kind).toBe('failed');
+    if (outcome.kind === 'failed') {
+      expect(outcome.step).toBe('resolve-version');
+      expect(outcome.output).toContain('cannot answer a version probe');
+    }
+  });
+
+  it('the pack-declared infrastructure shape classifies too (uv without a venv)', async () => {
+    const cwd = tempRepo({
+      'pyproject.toml': '[project]\nname = "fx"\nversion = "0.1.0"\ndependencies = []\n',
+      'uv.lock': 'version = 1\n',
+      'app.py': 'import yaml\n',
+    });
+    const { exec } = fakeExec((cmd) => {
+      if (cmd.bin === 'uv' && cmd.args[0] === 'pip') {
+        return {
+          code: 2,
+          output: 'error: No virtual environment found; run `uv venv` to create an environment',
+        };
+      }
+      return undefined;
+    });
+    const order = makeOrder({
+      id: 'unresolved-import:python:.',
+      class: 'unresolved-import',
+      findings: [
+        floorFinding('python/import-resolution#yaml', 'python', 'import-resolution', {
+          specifier: 'yaml',
+          importingFiles: ['app.py'],
+        }),
+      ],
+      envelope: { paths: ['app.py', 'pyproject.toml', 'uv.lock'], manifests: true },
+      constraints: { install: { bin: 'uv', args: ['sync', '--locked'] }, forbidden: [] },
+    });
+    const outcome = await executeDeclareDependency(order, makeCtx(cwd, { exec }));
+    expect(outcome.kind).toBe('failed');
+    if (outcome.kind === 'failed') {
+      expect(outcome.step).toBe('resolve-version');
+      expect(outcome.output).toContain('cannot answer a version probe');
+      expect(outcome.output).toContain('No virtual environment');
+    }
   });
 
   it('fails verify when the specifier still does not resolve after the install', async () => {

--- a/test/remediate/recipes/override-pin.test.ts
+++ b/test/remediate/recipes/override-pin.test.ts
@@ -13,6 +13,8 @@ import {
   isConcreteSemver,
   pickPinVersion,
 } from '../../../src/remediate/recipes/shared';
+import { rubyRemediation } from '../../../src/languages/ruby-remediation';
+import type { PinTransitiveProvider } from '../../../src/languages/capabilities/remediation';
 import { advisoryFinding, depFinding, fakeExec, makeCtx, makeOrder, tempRepo } from './helpers';
 
 const PKG = JSON.stringify({ name: 'fx', version: '1.0.0', dependencies: { top: '^1.0.0' } });
@@ -42,6 +44,48 @@ describe('the pin choice (semver precedence, prerelease rules included)', () => 
     expect(isConcreteSemver('>=4.1.0')).toBe(false);
     expect(isConcreteSemver('^4.1.0')).toBe(false);
     expect(pickPinVersion(['4.1.0', '>=4.1.1'])).toBeNull();
+  });
+
+  it('honors a pack-declared version grammar: RubyGems 4-segment fixes pick numerically', () => {
+    const scheme = (rubyRemediation.pinTransitive as { provider: PinTransitiveProvider }).provider
+      .versions!;
+    // The default x.y.z grammar refuses the rails-family fix shape...
+    expect(pickPinVersion(['6.1.7.10', '6.1.7.9'])).toBeNull();
+    // ...the owning pack's grammar pins it, ordered numerically.
+    expect(pickPinVersion(['6.1.7.10', '6.1.7.9'], scheme)).toBe('6.1.7.10');
+    expect(pickPinVersion(['7.0.8', '7.0.8.7'], scheme)).toBe('7.0.8.7');
+    expect(pickPinVersion(['7.0.8.7', '>= 7.0.8'], scheme)).toBeNull();
+  });
+});
+
+describe('override-pin recipe (php pack: composer require pin + churn disclosure)', () => {
+  const COMPOSER = JSON.stringify(
+    { name: 'acme/app', require: { 'guzzlehttp/guzzle': '^7.8' } },
+    null,
+    2,
+  );
+
+  it('applies through the composer declarations and carries the deliberate-churn note', async () => {
+    const cwd = tempRepo({ 'composer.json': COMPOSER + '\n', 'composer.lock': '{}' });
+    const { exec, calls } = fakeExec();
+    const order = makeOrder({
+      id: 'dep-advisory:guzzlehttp/psr7',
+      class: 'dep-advisory',
+      findings: [advisoryFinding('f1', 'guzzlehttp/psr7', 'GHSA-pppp', '2.7.1')],
+      envelope: { paths: ['composer.json', 'composer.lock'], manifests: true },
+    });
+    const outcome = await executeOverridePin(order, makeCtx(cwd, { exec }));
+    expect(outcome.kind).toBe('applied');
+    const manifest = JSON.parse(fs.readFileSync(path.join(cwd, 'composer.json'), 'utf8')) as {
+      require: Record<string, string>;
+    };
+    expect(manifest.require['guzzlehttp/psr7']).toBe('2.7.1');
+    expect(calls.some((c) => c.cmd.bin === 'composer' && c.cmd.args[0] === 'update')).toBe(true);
+    if (outcome.kind === 'applied') {
+      expect(outcome.changedFiles).toEqual(['composer.json', 'composer.lock']);
+      expect(outcome.notes?.join(' ')).toContain('unrelated packages');
+      expect(outcome.revert).toContain('guzzlehttp/psr7');
+    }
   });
 });
 

--- a/test/remediate/work-orders/recipes.test.ts
+++ b/test/remediate/work-orders/recipes.test.ts
@@ -193,21 +193,111 @@ describe('order-intrinsic feasibility lives in matches (an executor-certain refu
     expect(tierOf({ ...ok, findings: [floorFinding('typescript', 'left-pad')] })).toBe('recipe');
     // A pack whose declaration is a (planned) exemption tiers agent AND the
     // order carries the declared reason for the plan surface (4.4.7 V1).
-    const python = assignTier({
+    const go = assignTier({
       ...draftBase,
       ...ok,
-      findings: [floorFinding('python', 'requests')],
+      findings: [floorFinding('go', 'github.com/x/y')],
     });
-    expect(python.tier).toBe('agent');
-    expect(python.capabilityExemption?.pack).toBe('python');
-    expect(python.capabilityExemption?.capability).toBe('declareDependency');
-    expect(python.capabilityExemption?.reason).toContain('python');
+    expect(go.tier).toBe('agent');
+    expect(go.capabilityExemption?.pack).toBe('go');
+    expect(go.capabilityExemption?.capability).toBe('declareDependency');
+    expect(go.capabilityExemption?.reason).toContain('go');
     expect(tierOf({ ...ok, findings: [floorFinding('typescript', '--registry=https://x')] })).toBe(
       'agent',
     );
     expect(tierOf({ ...ok, findings: [floorFinding('typescript', './src/missing')] })).toBe(
       'agent',
     );
+  });
+
+  it('the wave-1 packs tier recipe through their declarations (python/ruby/php, 4.4.7 V2)', () => {
+    // declare-dependency: python maps the import through the one alias
+    // table; an ambiguous alias (cv2 serves three distributions) fails the
+    // rail and tiers agent. Ruby rides the gem-name rail; a nested require
+    // path names a file inside a gem, not a gem.
+    const pyDeclare = {
+      id: 'unresolved-import:python:.',
+      class: 'unresolved-import' as const,
+      envelope: { paths: ['pyproject.toml', 'uv.lock'], manifests: true },
+    };
+    expect(tierOf({ ...pyDeclare, findings: [floorFinding('python', 'requests')] })).toBe('recipe');
+    expect(tierOf({ ...pyDeclare, findings: [floorFinding('python', 'yaml')] })).toBe('recipe');
+    expect(tierOf({ ...pyDeclare, findings: [floorFinding('python', 'cv2')] })).toBe('agent');
+    const rbDeclare = {
+      id: 'unresolved-import:ruby:.',
+      class: 'unresolved-import' as const,
+      envelope: { paths: ['Gemfile', 'Gemfile.lock'], manifests: true },
+    };
+    expect(tierOf({ ...rbDeclare, findings: [floorFinding('ruby', 'nokogiri')] })).toBe('recipe');
+    expect(
+      tierOf({ ...rbDeclare, findings: [floorFinding('ruby', 'active_support/core_ext')] }),
+    ).toBe('agent');
+    // php: a namespace does not identify a Packagist package, a declared
+    // exemption, disclosed on the order.
+    const php = assignTier({
+      ...draftBase,
+      id: 'unresolved-import:php:.',
+      class: 'unresolved-import' as const,
+      envelope: { paths: ['composer.json', 'composer.lock'], manifests: true },
+      findings: [floorFinding('php', 'Monolog')],
+    });
+    expect(php.tier).toBe('agent');
+    expect(php.capabilityExemption?.capability).toBe('declareDependency');
+    expect(php.capabilityExemption?.reason).toContain('Packagist');
+
+    // override-pin: the three packs resolve through their declared
+    // manifests; the concrete-semver rail still applies.
+    const pin = (pack: string, paths: string[], fixedVersion: string) =>
+      tierOf({
+        id: 'dep-advisory:p',
+        class: 'dep-advisory' as const,
+        envelope: { paths, manifests: true },
+        findings: [
+          {
+            kind: 'dep-vuln',
+            id: 'a',
+            attribution: 'deferred' as const,
+            evidence: {
+              type: 'dep-vuln' as const,
+              package: 'p',
+              advisoryId: 'GHSA-1',
+              fixedVersion,
+              pack,
+            },
+          },
+        ],
+      });
+    expect(pin('python', ['pyproject.toml', 'uv.lock'], '2.5.0')).toBe('recipe');
+    expect(pin('ruby', ['Gemfile', 'Gemfile.lock'], '1.16.5')).toBe('recipe');
+    expect(pin('php', ['composer.json', 'composer.lock'], '2.4.5')).toBe('recipe');
+    expect(pin('python', ['pyproject.toml'], '>=2.5')).toBe('agent');
+
+    // lockfile-sync: python + php declare the capability AND a lockfile
+    // check, so a one-root envelope tiers recipe; ruby's declaration rides
+    // its (disclosed-skip) check the same way.
+    const stale = (pack: string, paths: string[]) =>
+      tierOf({
+        id: `stale-lockfile:${pack}`,
+        class: 'stale-lockfile' as const,
+        envelope: { paths, manifests: true },
+        findings: [floorFinding(pack)],
+      });
+    expect(stale('python', ['pyproject.toml', 'poetry.lock'])).toBe('recipe');
+    expect(stale('ruby', ['Gemfile', 'Gemfile.lock'])).toBe('recipe');
+    expect(stale('php', ['composer.json', 'composer.lock'])).toBe('recipe');
+
+    // lint-autofix: ruff and rubocop declare fix modes; phpcs cannot
+    // fix-and-verify in one run, a declared exemption.
+    const lint = (check: string) =>
+      tierOf({
+        id: 'lint-located:src/a',
+        class: 'lint-located' as const,
+        envelope: { paths: ['src/a'], manifests: false },
+        findings: [lintFinding(check)],
+      });
+    expect(lint('lint:python')).toBe('recipe');
+    expect(lint('lint:ruby')).toBe('recipe');
+    expect(lint('lint:php')).toBe('agent');
   });
 
   it('lint-autofix: a user check or a fixCommand-less pack tiers agent; a SLICED order stays recipe (grouped fix)', () => {

--- a/test/remediate/work-orders/recipes.test.ts
+++ b/test/remediate/work-orders/recipes.test.ts
@@ -271,20 +271,38 @@ describe('order-intrinsic feasibility lives in matches (an executor-certain refu
     expect(pin('ruby', ['Gemfile', 'Gemfile.lock'], '1.16.5')).toBe('recipe');
     expect(pin('php', ['composer.json', 'composer.lock'], '2.4.5')).toBe('recipe');
     expect(pin('python', ['pyproject.toml'], '>=2.5')).toBe('agent');
+    // The version grammar is pack-declared (Rule 6): RubyGems 4-segment
+    // security releases (the rails-family shape) and PyPI 2-segment
+    // releases tier recipe under their packs' schemes, while an
+    // unorderable PEP 440 marker and npm's x.y.z default both refuse.
+    expect(pin('ruby', ['Gemfile', 'Gemfile.lock'], '7.0.8.7')).toBe('recipe');
+    expect(pin('python', ['pyproject.toml', 'uv.lock'], '2.31')).toBe('recipe');
+    expect(pin('python', ['pyproject.toml', 'uv.lock'], '2.31.post1')).toBe('agent');
+    expect(pin('typescript', ['package.json', 'package-lock.json'], '1.2.3.4')).toBe('agent');
 
-    // lockfile-sync: python + php declare the capability AND a lockfile
-    // check, so a one-root envelope tiers recipe; ruby's declaration rides
-    // its (disclosed-skip) check the same way.
-    const stale = (pack: string, paths: string[]) =>
-      tierOf({
-        id: `stale-lockfile:${pack}`,
-        class: 'stale-lockfile' as const,
-        envelope: { paths, manifests: true },
-        findings: [floorFinding(pack)],
-      });
+    // lockfile-sync: python + php declare the capability AND a verifiable
+    // sync check, so a one-root envelope tiers recipe. Ruby's sync check
+    // is a DECLARED skip: the executor could never confirm a resync
+    // (certain discard), so the order tiers agent with the pack's own
+    // skip reason disclosed; same doctrine for a yarn-lockfile envelope
+    // under the typescript pack.
+    const staleOrder = (pack: string, paths: string[]) => ({
+      ...draftBase,
+      id: `stale-lockfile:${pack}`,
+      class: 'stale-lockfile' as const,
+      envelope: { paths, manifests: true },
+      findings: [floorFinding(pack)],
+    });
+    const stale = (pack: string, paths: string[]) => assignTier(staleOrder(pack, paths)).tier;
     expect(stale('python', ['pyproject.toml', 'poetry.lock'])).toBe('recipe');
-    expect(stale('ruby', ['Gemfile', 'Gemfile.lock'])).toBe('recipe');
     expect(stale('php', ['composer.json', 'composer.lock'])).toBe('recipe');
+    const ruby = assignTier(staleOrder('ruby', ['Gemfile', 'Gemfile.lock']));
+    expect(ruby.tier).toBe('agent');
+    expect(ruby.capabilityExemption?.capability).toBe('resyncLockfile');
+    expect(ruby.capabilityExemption?.reason).toContain('could never be verified');
+    expect(ruby.capabilityExemption?.reason).toContain('bundler');
+    expect(stale('typescript', ['package.json', 'yarn.lock'])).toBe('agent');
+    expect(stale('typescript', ['package.json', 'package-lock.json'])).toBe('recipe');
 
     // lint-autofix: ruff and rubocop declare fix modes; phpcs cannot
     // fix-and-verify in one run, a declared exemption.


### PR DESCRIPTION
## What

The 4.4.7 V2 unit: python, ruby and php replace their planned remediation exemptions with real pack declarations, so the deterministic recipe tier (V1, #355) serves non-JS repos. Every capability is either implemented where the ecosystem genuinely supports it or a reasoned exemption the plan discloses; nothing guesses.

Per-pack matrix:

| capability | python | ruby | php |
|---|---|---|---|
| resyncLockfile | capability: rides the strategy; poetry gains a resync (`poetry lock --no-update`, plain `poetry lock` as the guarded unsupported-flag fallback for poetry 2) and all three lock managers gain sync checks (`poetry check --lock`, `uv lock --check`, `pipenv verify`); plain requirements roots have no lockfile and decline at the executor with the reason | capability: `bundle install` resync; the sync check is a DISCLOSED skip (bundler has no non-installing dry-run; `bundle check` needs installed gems and may rewrite the lockfile), the pnpm/yarn precedent | capability: `composer update` resync; the sync check is `composer validate --no-check-all --no-check-publish`, which exits non-zero on a stale lock (verified against composer 2.9: exit 2) |
| pinTransitive | capability, per manager: uv gets its real override surface (`[tool.uv] override-dependencies`); poetry and pipenv get the ecosystem's explicit-entry pin; pip/requirements refuses with the reason (no lockfile to verify against) | capability: the Gemfile explicit-entry pin (bundler has no override table); refuses a directly declared gem | capability: the exact-version `require` pin, composer's documented way to constrain a transitive; the `conflict`+`require` alternative was deliberately not chosen (the provider doc says why: conflict alone cannot force a resolution and fails opaquely) |
| declareDependency | capability: the ONE import-to-distribution table (shared with the resolution check) is the rail, so `import yaml` installs pyyaml and an ambiguous alias (cv2, google) stays on the agent tier; `pip index versions` probe, per-manager install command | capability: `bundle add --version` behind the gem-name rail (no slash: a nested require path is a file, not a gem); a require whose name is not a published gem refuses at the `gem search --exact` probe rather than installing a guess | EXEMPTION with reason: the php resolution check reports unresolved NAMESPACES, and a namespace does not identify a Packagist package; deriving vendor/package mechanically would be a guess |
| lintFix | capability: `ruff check --fix` fixCommand, file-scoped, leftovers through the same json parser the gate uses | capability: `rubocop -a` (safe cops only) with a fix-mode parser dropping offenses the run itself corrected | EXEMPTION with reason: phpcbf reports what it fixed, not what remains, so one run cannot fix and verify; a different fixer would not answer the phpcs gate's sniffs |

Supporting moves, each the smallest honest shape:

- `python-install.ts` split out of `python.ts` (the node-install.ts precedent) so the remediation module reads the SAME strategy without a cycle; `python-dist-names.ts` is the one home of the import/distribution alias table, now consumed by both the resolution check and the declare capability (Rule 2.30).
- All three packs gain `correctness.lockfileCheck` derived through the one `lockfileCheckFromStrategy` derivation. Without it the resync capability would have been armed but structurally dead: the floor could never mint a stale-lockfile order for these packs.
- `uv.lock` joins python's dep-vuln `manifestPatterns`, so order envelopes carry it and a lockfile-only PR re-audits.
- Rule 11 rails everywhere both pin tokens land in manifest text verbatim: package and version shapes are checked per ecosystem before any edit exists, and every transform is total over garbage (refuses, never throws).
- Rule 20: every provider declares `execution(cwd)` on the pack's ambient toolchain.

## How it is tested

- `test/languages/{python,ruby,php}-remediation.test.ts`: pure transforms on real manifest fixtures (applied / refused / adversarial: direct deps in every section shape, existing override lists, PEP 621 poetry layouts, garbage, injection-shaped tokens), probe parsers total over garbage, per-manager install commands, the alias-mapping rail, and the rubocop corrected-offense filter.
- `test/remediate/work-orders/recipes.test.ts`: the planner tiers wave-1 orders `recipe` through the declarations across all four capabilities, refusal directions included; the exemption-disclosure case moves to the still-planned go pack.
- `test/remediate/recipes/declare-dependency.test.ts`: an executor-level python apply proving probe + install name the distribution (pyyaml), verified by the pack's own resolution check.
- `test/remediate/e2e-rethink.test.ts`: the fixture-matrix row the design demands: the estate harness is now pack-parametric, and two python (uv) scenarios land recipe-only fixes (override pin, lockfile resync) end to end with a THROWING driver: zero agent spawns, every command through uv, never npm.
- The V1 contract tests (`languages-contract`) and the install parity net now exercise the real providers for the three packs (that is where the poetry fallback's `shellGuard` requirement was caught and fixed).

## Sweep + guardrail

- `npm run typecheck` + `typecheck:test`: clean
- `npx eslint . --max-warnings 0`: clean
- `npx prettier --check .`: clean
- `bash scripts/check-architecture.sh`: exit 0 (one pre-existing stderr line from the script itself, present on the base branch)
- `bash scripts/check-docs-coverage.sh`: clean
- `DXKIT_SLOP_BASE=origin/main bash scripts/check-slop.sh`: exit 0
- `npm run build`: clean
- `npx vitest run --coverage`: 431 files, 6572 tests, all passing; coverage 75.49% (threshold 50%)
- `node dist/index.js guardrail check --mode ref-based --ref origin/main`: PASSED, exit 0 (0 blocking, 88 persisted)

## Review focus

- The poetry resync ladder: `poetry lock --no-update` primary, plain `poetry lock` as the unsupported-flag fallback with a version-gated `shellGuard`. The classifier only matches a flag REJECTION naming `--no-update`, never a resolution failure.
- The pin transforms' refusal coverage: is any manifest shape missing where a pure edit could silently corrupt rather than refuse? The bias is to refuse; the parity/contract tests pin totality but judgment on the shapes is welcome.
- The php `declareDependency` and `lintFix` exemptions, and python's ambiguous-alias refusals: these are deliberate scope calls (an exemption with a reason is parity; a guess is not).
- `uv.lock` joining python `manifestPatterns`: also affects the guardrail's incremental dep-audit skip (a uv.lock-only diff now re-audits), which looks like a strict improvement.

## Deliberately left out

- pip constraints files for `pinTransitive`: a requirements root has no lockfile the executor could verify a pin against, so the mechanism would be dead code behind the existing lockfile-null refusal; declared as a per-manager refusal with the reason instead.
- A php `declareDependency` implementation via namespace-to-package guessing, and a pint/php-cs-fixer `lintFix`: both would violate the false-negative bias or the seam's one-run fix-and-verify contract (reasons in the provider doc and the exemptions themselves).
- go/rust/jvm/csharp/swift: planned exemptions, V3 owns them.

## Review round 1 (commit b55f4b6b): 3 majors + 5 minors + 3 nits, all closed

1. **Dotted TOML keys (major)**: the poetry and pipenv pin transforms now always quote the inserted key, so `zope.interface` can never parse as a dotted key (a `zope` table with garbage). Dotted fixtures pin the applied AND direct-dep-refusal directions for both managers.
2. **psycopg2 + table re-audit (major)**: the import-to-distribution table is documented as an install decision and re-audited under that bias. `psycopg2` now names its two genuinely distinct distributions and refuses to the agent tier; `snowflake` gains snowpark (connector vs snowpark both own the namespace); `jwt` keeps pyjwt with the justification inline (the homonym dist is niche); PEP 503 spelling duplicates dropped (the one fold handles them, nit 10).
3. **Pack-declared version grammar (major, root fix)**: `PinTransitiveProvider.versions` (`concrete` + `compare`, semver default) is consumed by the registry's `matches` and the executor's `pickPinVersion` through ONE resolution (`pinVersionScheme`), so the tier decision and the runtime pick cannot grade a fixed version differently. Ruby accepts numeric 4-segment fixes (`7.0.8.7`, ordered numerically: `6.1.7.10` outranks `6.1.7.9`); python accepts plain PEP 440 releases (`2.31`) and refuses unorderable markers (`2.31.post1`, epochs, locals). TypeScript is byte-unchanged (its executor suite passes unmodified); the contract row pins any declared grammar deterministic and range-refusing.
4. **Composer resync churn (minor, the "your call" item)**: chose the doctrine-note + ledger-disclosure path over a `resyncScoped` seam. Reason: the resync plan is ONE mode shared by the lockfile-sync recipe (which needs the full-tree form) and the frame's tree invariants; a per-package scoped variant would fork the install seam for a single consumer, against Rule 2. The pin plan now carries pack-declared `notes` that the executor rides onto the applied outcome's ledger line ("may also refresh unrelated packages in composer.lock..."), pinned by a new php executor apply test.
5. **Ruby stale-lockfile tier (minor)**: a declared-skip sync check is a certain executor discard, so the registry tiers such orders agent with the pack's own skip reason disclosed (`capabilityExemption`); same doctrine bites a yarn-lockfile envelope under the typescript pack. Deliberately narrow: only a DECLARED skip decides; a pack whose `lockfileCheck` does not derive from a strategy sync check (the synthetic playbook pack) stays recipe-tiered with the executor's verify as the runtime authority, so the projection can never over-rule a verifiable check it cannot see.
6. **poetry check scoping (minor)**: the sync check may declare a non-drift `classifyFailure` (threaded through the one derivation into the one check executor); poetry classifies a failure that never mentions the lock as `manifest-validation` with the remedy pointed at the manifest, never at re-locking. Floor tests pin both directions.
7. **PEP 735 (minor)**: `[dependency-groups]` joins the uv direct-dep scan (it is what the pack's own `uv add --dev` writes); test added.
8. **uv probe (minor)**: a uv-managed root probes through `uv pip install --dry-run --no-deps` (uv venvs ship without pip), parsed by the same total parser; an infrastructure-shaped probe failure (generic unknown-command shapes, plus the pack-declared `probeInfrastructure` for uv's no-venv error) is a named `resolve-version` failure, never a "likely a typo" refusal. Both directions tested.
9-11. **Nits**: test-header em-dash removed; the name fold consolidated onto `normalizePyDistName` (two local folds retired); documented residuals added for the Gemfile `gemspec` directive gap and the TOML multiline-string false-match (both fail loudly at resync/verify and the diff is discarded, never a silent wrong landing).

Round sweep: typecheck + typecheck:test + eslint + prettier + arch-check + docs-coverage + slop all clean; full `vitest run --coverage` 431 files / 6585 tests green, coverage 75.55%; `guardrail check --mode ref-based --ref origin/main` PASSED exit 0; diff greps for banned names and em-dashes: 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)