### PR TITLE
feat(languages): go/rust/jvm/csharp/swift remediation fills (4.4.7 V3)

### DIFF
--- a/src/analyzers/correctness/lockfile-check.ts
+++ b/src/analyzers/correctness/lockfile-check.ts
@@ -196,12 +196,19 @@ export function executeLockfileCheck(
       // A further tolerated-class failure with the ladder exhausted keeps
       // the disclosed pass (the pre-fix semantics, now the LAST resort).
       if (notes.length > 0 && retries.some((r) => r.matches(attempt.output))) return pass();
-      // A pack-declared NON-DRIFT classification (poetry check validates
-      // the whole pyproject alongside the lock) replaces the resync remedy
-      // with the pack's own disclosure: the check still fails (the frozen
-      // install fails on this tree either way), but the cause is named so
-      // a manifest error is never read, or remediated, as lockfile drift.
+      // A pack-declared classification decides what a non-tolerated
+      // failure means (see `SyncCheckClassification`):
+      //   - `{ skipped }`: the check CANNOT JUDGE here (an EOL toolchain
+      //     missing the dry-run flag). A disclosed skip, never a fail: a
+      //     fail would mint a stale-lockfile order every run whose resync
+      //     can only be discarded again.
+      //   - a string: a real NON-DRIFT failure (poetry check validates the
+      //     whole pyproject alongside the lock); the check still fails,
+      //     with the pack's disclosure instead of the resync remedy.
       const classified = check.classifyFailure?.(attempt.output) ?? null;
+      if (classified !== null && typeof classified === 'object') {
+        return { ...base, status: 'skipped-unavailable', output: classified.skipped };
+      }
       return {
         ...base,
         status: 'fail',

--- a/src/languages/capabilities/correctness.ts
+++ b/src/languages/capabilities/correctness.ts
@@ -222,9 +222,9 @@ export type LockfileCheck =
       readonly kind: 'command';
       readonly command: CorrectnessCommand;
       readonly tolerated?: readonly ToleratedCheckRetry[];
-      /** The strategy's declared non-drift classifier, passed through by
-       *  the one derivation below (see `LockfileSyncCheck`). */
-      readonly classifyFailure?: (output: string) => string | null;
+      /** The strategy's declared failure classifier, passed through by
+       *  the one derivation below (see `SyncCheckClassification`). */
+      readonly classifyFailure?: (output: string) => SyncCheckClassification;
     }
   | { readonly kind: 'skipped'; readonly reason: string };
 
@@ -276,7 +276,7 @@ export function lockfileCheckFromStrategy(
 }
 
 import type { ExecutionRequirement } from '../../execution';
-import type { InstallStrategy } from './install-strategy';
+import type { InstallStrategy, SyncCheckClassification } from './install-strategy';
 
 /**
  * A pack's correctness-floor provider. Both methods are pure command builders —

--- a/src/languages/capabilities/install-strategy.ts
+++ b/src/languages/capabilities/install-strategy.ts
@@ -156,6 +156,22 @@ export interface InstallPlan {
 }
 
 /**
+ * What a sync check's declared failure classifier may answer:
+ *   - a STRING: the failure is real but is NOT lockfile drift (poetry's
+ *     check validates the whole pyproject alongside the lock); the full
+ *     disclosure sentence is printed INSTEAD of the resync remedy, and the
+ *     check still FAILS (the frozen install fails on this tree either way).
+ *   - `{ skipped }`: the check CANNOT JUDGE here at all (an EOL toolchain
+ *     whose dry-run flag does not exist). A disclosed SKIP, never a fail:
+ *     a fail would mint a stale-lockfile order every run whose resync can
+ *     only be discarded again, a wasted spawn per run forever.
+ *   - null: a real drift; the standard resync remedy applies.
+ * Pure; biased toward false negatives (uncertain output keeps the drift
+ * reading).
+ */
+export type SyncCheckClassification = string | { readonly skipped: string } | null;
+
+/**
  * A non-installing "would the frozen install succeed?" check (the floor's
  * lockfile-sync tier), or a disclosed skip for an ecosystem whose manager
  * has no reliable dry-run. `tolerates` names the classes whose fallback
@@ -168,16 +184,9 @@ export type LockfileSyncCheck =
       readonly kind: 'command';
       readonly command: InstallCommand;
       readonly tolerates: readonly ToleranceClass[];
-      /**
-       * OPTIONAL classifier for a failure that is NOT lockfile drift, when
-       * the ecosystem's only check also validates other things (poetry
-       * check validates the whole pyproject alongside the lock). Returns
-       * the full disclosure sentence to print INSTEAD of the resync
-       * remedy, or null for a real drift. Pure; biased toward false
-       * negatives (uncertain output keeps the drift reading, since the
-       * frozen install would fail on it either way).
-       */
-      readonly classifyFailure?: (output: string) => string | null;
+      /** OPTIONAL classifier for a failure that is not a plain drift; see
+       *  `SyncCheckClassification` for the three answers. */
+      readonly classifyFailure?: (output: string) => SyncCheckClassification;
     }
   | { readonly kind: 'skipped'; readonly reason: string };
 

--- a/src/languages/capabilities/remediation.ts
+++ b/src/languages/capabilities/remediation.ts
@@ -120,6 +120,30 @@ export type PinPlanResult =
        *  unrelated packages). Prose the ledger prints verbatim. */
       readonly notes?: readonly string[];
     }
+  | {
+      /**
+       * A tool-owned pin (4.4.7 V3): the ecosystem's OWN command applies
+       * the pin and writes the manifest/lockfile itself. The shape exists
+       * for the compiled ecosystems whose dependency files are
+       * tool-maintained formats a text transform must never touch: `go
+       * get pkg@version` rewrites go.mod + go.sum through the go tool,
+       * and `cargo update -p pkg --precise version` rewrites Cargo.lock
+       * through cargo. The executor runs the command at the owning root
+       * through the injected bounded exec and skips the separate lock
+       * resync: the tool's one command leaves the tree consistent, which
+       * is exactly why this shape is preferred over a hand edit there.
+       */
+      readonly kind: 'command';
+      readonly command: InstallCommand;
+      /** Root-relative files the command rewrites (the applied outcome's
+       *  changedFiles; the runner's envelope enforcement re-reads git for
+       *  ground truth). */
+      readonly writes: readonly string[];
+      /** How a human undoes the pin, rendered in ledger prose. */
+      readonly revert: string;
+      /** Pack-declared side-effect disclosures for the ledger. */
+      readonly notes?: readonly string[];
+    }
   | { readonly kind: 'refused'; readonly reason: string };
 
 /**
@@ -141,6 +165,64 @@ export interface PinVersionScheme {
   /** Total order over versions `concrete` accepted. */
   compare(a: string, b: string): number;
 }
+
+/** A CONCRETE semver (x.y.z with optional prerelease/build), never a range.
+ *  A range-shaped "fixed version" (`>=4.1.0`) cannot be pinned verbatim, so
+ *  orders carrying one tier to the agent instead of guessing. */
+const CONCRETE_SEMVER =
+  /^\d+\.\d+\.\d+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/;
+
+export function isConcreteSemver(version: string): boolean {
+  return CONCRETE_SEMVER.test(version);
+}
+
+/** Semver precedence for CONCRETE versions, prerelease rules included: a
+ *  release outranks its prereleases (1.2.3 > 1.2.3-beta.1), prerelease
+ *  identifiers compare numerically when numeric, bytewise otherwise, and a
+ *  longer identifier list wins over its prefix (semver.org section 11). */
+export function compareConcreteSemver(a: string, b: string): number {
+  const parse = (v: string) => {
+    const [core] = v.split('+');
+    const [nums, ...preParts] = core.split('-');
+    return {
+      nums: nums.split('.').map(Number),
+      pre: preParts.length > 0 ? preParts.join('-').split('.') : null,
+    };
+  };
+  const pa = parse(a);
+  const pb = parse(b);
+  for (let i = 0; i < 3; i++) {
+    if (pa.nums[i] !== pb.nums[i]) return pa.nums[i] - pb.nums[i];
+  }
+  if (pa.pre === null && pb.pre === null) return 0;
+  if (pa.pre === null) return 1;
+  if (pb.pre === null) return -1;
+  for (let i = 0; i < Math.max(pa.pre.length, pb.pre.length); i++) {
+    const x = pa.pre[i];
+    const y = pb.pre[i];
+    if (x === undefined) return -1;
+    if (y === undefined) return 1;
+    const xn = /^\d+$/.test(x);
+    const yn = /^\d+$/.test(y);
+    if (xn && yn) {
+      if (Number(x) !== Number(y)) return Number(x) - Number(y);
+    } else if (xn !== yn) {
+      return xn ? -1 : 1; // numeric identifiers rank below alphanumeric
+    } else if (x !== y) {
+      return x < y ? -1 : 1;
+    }
+  }
+  return 0;
+}
+
+/** The default pin-version grammar: the x.y.z semver shape. Packs whose
+ *  advisories carry other concrete forms declare their own scheme (Rule 6).
+ *  Lives beside `PinVersionScheme` so a pack composing on the semver order
+ *  (go's v-prefixed grammar) reads the ONE comparator, never a copy. */
+export const DEFAULT_PIN_VERSIONS: PinVersionScheme = {
+  concrete: isConcreteSemver,
+  compare: compareConcreteSemver,
+};
 
 /** Numeric dotted-segment comparison (missing segments read as 0): the
  *  shared comparator for release-only version schemes (RubyGems and PyPI

--- a/src/languages/capabilities/remediation.ts
+++ b/src/languages/capabilities/remediation.ts
@@ -84,6 +84,18 @@ export interface ResyncLockfileProvider {
    * declares no command of its own).
    */
   readonly manifestFiles: readonly string[];
+  /**
+   * OPTIONAL per-repo admission check, consulted by the lockfile-sync
+   * executor AFTER the owning root resolves and BEFORE anything runs: a
+   * repo shape where the pack's declared resync would be unsound refuses
+   * with the reason (pure fs reads only, never a spawn). The go pack is
+   * the motivating case: on a vendored module `go mod tidy` leaves
+   * vendor/modules.txt behind (an inconsistent-vendoring tree the floor
+   * only catches post-commit), and under a go.work workspace the go tool
+   * also rewrites go.work.sum OUTSIDE the order's envelope, so the
+   * enforcement step would discard half the fix. Null = proceed.
+   */
+  refusal?(ctx: { readonly cwd: string; readonly rootDir: string }): string | null;
 }
 
 // ── pinTransitive ──────────────────────────────────────────────────────────
@@ -252,6 +264,14 @@ export interface PinTransitiveProvider {
    *  nothing) yielding the edit + revert prose, or a refusal with the
    *  reason (an override mechanism the pack does not implement yet). */
   plan(ctx: PinContext): PinPlanResult;
+  /**
+   * OPTIONAL: the form of a concrete version as OSV stores it for this
+   * ecosystem, consumed by the executor's $0 pre-check. The go ecosystem
+   * is the case: modules spell versions vX.Y.Z while OSV's `Go` records
+   * carry the bare X.Y.Z, and a v-prefixed query silently matches nothing
+   * (an empty answer reads as clean). Defaults to identity. Pure.
+   */
+  osvVersion?(version: string): string;
   /** What applying the pin needs from the environment (Rule 20). Pure and
    *  repo-intrinsic, the install-strategy discipline. */
   execution(cwd: string): ExecutionRequirement;

--- a/src/languages/csharp.ts
+++ b/src/languages/csharp.ts
@@ -1,5 +1,5 @@
 import { NO_TREE_INVARIANTS } from './capabilities/tree-invariants';
-import { plannedRemediationSupport } from './capabilities/remediation';
+import type { RemediationSupport } from './capabilities/remediation';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -1760,6 +1760,58 @@ function detectCsharpVersion(cwd: string): string | undefined {
   return undefined;
 }
 
+/**
+ * The csharp pack's remediation declarations: four reasoned exemptions
+ * (4.4.7 V3), each naming the future mechanism.
+ *
+ *   - The dependency-shaped recipes derive the owning root from a
+ *     pack-declared list of manifest BASENAMES, and .NET project manifests
+ *     have repo-specific basenames (MyApp.csproj), so no declaration can
+ *     name them today; NuGet lockfiles (packages.lock.json) are also a
+ *     per-project opt-in living beside each csproj. The fills graduate
+ *     when the seam grows a pattern-aware root derivation.
+ *   - pinTransitive additionally means a csproj / Directory.Packages.props
+ *     XML edit, hand-authored XML a mechanical edit can corrupt.
+ *   - declareDependency: the compiler is the resolution floor here (no
+ *     resolutionCheck), so unresolved-import orders are never minted.
+ *   - lintFix: the gate reads Roslyn analyzer warnings out of
+ *     `dotnet build`, while `dotnet format` reports what it CHANGED rather
+ *     than the analyzer findings that remain, so one run cannot both fix
+ *     and verify an order's findings (the phpcbf class).
+ */
+const csharpRemediation: RemediationSupport = {
+  resyncLockfile: {
+    kind: 'exemption',
+    reason:
+      'NuGet lockfiles (packages.lock.json) are a per-project opt-in living beside each ' +
+      '.csproj, and .NET project manifests have repo-specific basenames the order envelope ' +
+      'cannot name by basename; these orders stay on the agent tier until a pattern-aware ' +
+      'root derivation exists',
+  },
+  pinTransitive: {
+    kind: 'exemption',
+    reason:
+      'a .NET transitive pin is a .csproj or Directory.Packages.props XML edit, ' +
+      'hand-authored XML a mechanical edit can corrupt, and per-project manifests have ' +
+      'repo-specific basenames the order envelope cannot name; the pin stays on the agent ' +
+      'tier until a provably pure project-file edit exists',
+  },
+  declareDependency: {
+    kind: 'exemption',
+    reason:
+      'the C# compiler is the import-resolution floor for this pack (no resolutionCheck is ' +
+      'declared), so unresolved-import orders are never minted and a declare could not be ' +
+      'resolution-verified; these orders stay on the agent tier',
+  },
+  lintFix: {
+    kind: 'exemption',
+    reason:
+      'the C# lint gate reads Roslyn analyzer warnings out of dotnet build, and dotnet ' +
+      'format reports what it changed rather than the findings that remain, so one run ' +
+      "cannot both fix and verify an order's findings; these orders stay on the agent tier",
+  },
+};
+
 export const csharp: LanguageSupport = {
   id: 'csharp',
   displayName: 'C#',
@@ -2032,7 +2084,7 @@ export const csharp: LanguageSupport = {
   deepSast: { codeqlLanguage: 'csharp', snykCode: true, execution: csharpBuildExecution },
 
   treeInvariants: NO_TREE_INVARIANTS,
-  remediation: plannedRemediationSupport('dotnet'),
+  remediation: csharpRemediation,
   correctness: csharpCorrectnessProvider,
   lintGate: csharpLintGateProvider,
 

--- a/src/languages/go-install.ts
+++ b/src/languages/go-install.ts
@@ -1,0 +1,67 @@
+/**
+ * How a Go module root installs (CLAUDE.md Rule 6), the
+ * node-install.ts / python-install.ts sibling, split out of `go.ts` so the
+ * remediation capabilities read the SAME strategy without a module cycle.
+ *
+ * Doctrine notes, kept beside the declarations they explain:
+ *   - go.sum is the lockfile: it records the checksums of every module the
+ *     build reads, and the go tool itself maintains it (go.mod + go.sum
+ *     are never hand-edited by dxkit anywhere).
+ *   - The frozen install is `go mod download`: it fetches exactly what
+ *     go.mod resolves and FAILS on a checksum mismatch against go.sum,
+ *     which is what every Go CI runs before building.
+ *   - The resync is `go mod tidy`: the one command that rewrites go.mod +
+ *     go.sum to record precisely what the source imports.
+ *   - The sync check is `go mod tidy -diff` (go 1.23+): the non-writing
+ *     dry-run that exits non-zero with the diff when go.mod / go.sum do
+ *     not record the source's imports. On an older toolchain the flag is
+ *     rejected ("flag provided but not defined"); the declared
+ *     classifier names that as a toolchain-age condition instead of
+ *     letting it read as lockfile drift (every supported Go release
+ *     carries the flag; the shape only appears on an EOL toolchain).
+ *   - No ecosystem tolerance exists here: the go resolver has no
+ *     peer-check analogue, so no repo-authorized fallbacks are declared.
+ */
+import type { ExecutionRequirement } from '../execution';
+import { declareInstallStrategy } from './capabilities/install-strategy';
+
+/** Module maintenance runs on the ambient Go toolchain, any host, no
+ *  build (`go mod` subcommands resolve and download, they do not compile). */
+export const GO_MOD_EXECUTION: ExecutionRequirement = {
+  hosts: ['any'],
+  toolchains: ['go'],
+  needsBuild: false,
+  buildTarget: 'none',
+  weight: 'cheap',
+};
+
+export const goInstallStrategy = declareInstallStrategy(
+  [
+    {
+      when: ['go.mod'],
+      strategy: {
+        manager: 'gomod',
+        lockfile: 'go.sum',
+        modes: {
+          frozen: { primary: { bin: 'go', args: ['mod', 'download'] }, fallbacks: [] },
+          resync: { primary: { bin: 'go', args: ['mod', 'tidy'] }, fallbacks: [] },
+        },
+        syncCheck: {
+          kind: 'command',
+          command: { bin: 'go', args: ['mod', 'tidy', '-diff'] },
+          tolerates: [],
+          // A rejected -diff flag is a toolchain-age fact, not drift: name
+          // it so an EOL Go install is never read, or remediated, as an
+          // out-of-sync module file.
+          classifyFailure: (output) =>
+            /flag provided but not defined.*-diff|unknown flag.*-diff/i.test(output)
+              ? 'toolchain-age: this Go toolchain predates go 1.23 (go mod tidy -diff), so the ' +
+                'module-sync state cannot be judged here; update the Go toolchain.'
+              : null,
+        },
+        execution: GO_MOD_EXECUTION,
+      },
+    },
+  ],
+  { ciDependencyInstall: false },
+);

--- a/src/languages/go-install.ts
+++ b/src/languages/go-install.ts
@@ -50,13 +50,17 @@ export const goInstallStrategy = declareInstallStrategy(
           kind: 'command',
           command: { bin: 'go', args: ['mod', 'tidy', '-diff'] },
           tolerates: [],
-          // A rejected -diff flag is a toolchain-age fact, not drift: name
-          // it so an EOL Go install is never read, or remediated, as an
-          // out-of-sync module file.
+          // A rejected -diff flag is a toolchain-age fact, not drift: the
+          // check CANNOT JUDGE on an EOL Go install, so it classifies as a
+          // disclosed SKIP (a fail here would mint a stale-lockfile order
+          // every run whose resync ends in the same flag error).
           classifyFailure: (output) =>
             /flag provided but not defined.*-diff|unknown flag.*-diff/i.test(output)
-              ? 'toolchain-age: this Go toolchain predates go 1.23 (go mod tidy -diff), so the ' +
-                'module-sync state cannot be judged here; update the Go toolchain.'
+              ? {
+                  skipped:
+                    'this Go toolchain predates go 1.23 (go mod tidy -diff), so the module-sync ' +
+                    'state cannot be judged here; update the Go toolchain',
+                }
               : null,
         },
         execution: GO_MOD_EXECUTION,

--- a/src/languages/go-remediation.ts
+++ b/src/languages/go-remediation.ts
@@ -95,9 +95,57 @@ function goModRequiresDirectly(goMod: string, pkg: string): boolean {
 function goModReplaces(goMod: string, pkg: string): boolean {
   const escaped = pkg.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   if (new RegExp(`^\\s*replace\\s+${escaped}(\\s|=)`, 'm').test(goMod)) return true;
-  // The block form: any line inside `replace ( ... )` starting with pkg.
-  const block = goMod.match(/^\s*replace\s*\(([\s\S]*?)^\s*\)/m);
-  return block !== null && new RegExp(`^\\s*${escaped}(\\s|=)`, 'm').test(block[1]);
+  // The block form: any line inside ANY `replace ( ... )` block starting
+  // with pkg (a go.mod may carry several blocks; the first-block-only scan
+  // was the shipped gap).
+  const entry = new RegExp(`^\\s*${escaped}(\\s|=)`, 'm');
+  for (const block of goMod.matchAll(/^\s*replace\s*\(([\s\S]*?)^\s*\)/gm)) {
+    if (entry.test(block[1])) return true;
+  }
+  return false;
+}
+
+/**
+ * Repo shapes where the go tool's own pin/resync would be UNSOUND, refused
+ * up front (pure fs reads, the seam's refusal bias):
+ *   - a VENDORED module (vendor/modules.txt beside go.mod): neither
+ *     `go get` nor `go mod tidy` refreshes the vendor tree, so the default
+ *     -mod=vendor build fails "inconsistent vendoring" AFTER the commit
+ *     (the floor catches it one run too late, burning a run per attempt);
+ *     the mechanical fix would need a `go mod vendor` step this seam does
+ *     not model yet.
+ *   - a go.work WORKSPACE at or above the root: the go tool also rewrites
+ *     go.work.sum, a file OUTSIDE the order's envelope, so the enforcement
+ *     step would discard it and commit an inconsistent go.sum/go.work.sum
+ *     pair.
+ */
+export function goTreeRefusal(cwd: string, rootDir: string): string | null {
+  const rootAbs = path.join(cwd, rootDir);
+  if (fs.existsSync(path.join(rootAbs, 'vendor', 'modules.txt'))) {
+    return (
+      'this module is vendored (vendor/modules.txt), and the go tool does not refresh the ' +
+      'vendor tree here (a go mod vendor step is needed too), so the build would fail with ' +
+      'inconsistent vendoring after the commit; this stays on the agent tier'
+    );
+  }
+  // go.work applies from the module directory up to (and including) the
+  // repo root; the go tool would also rewrite go.work.sum there.
+  let dir = rootAbs;
+  const stop = path.resolve(cwd);
+  for (;;) {
+    if (fs.existsSync(path.join(dir, 'go.work'))) {
+      return (
+        'a go.work workspace governs this module, and the go tool would also rewrite ' +
+        "go.work.sum outside the order's envelope (the change would be discarded and the " +
+        'sum files left inconsistent); this stays on the agent tier'
+      );
+    }
+    if (path.resolve(dir) === stop) break;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
 }
 
 const goPinTransitive: PinTransitiveProvider = {
@@ -122,6 +170,8 @@ const goPinTransitive: PinTransitiveProvider = {
         reason: `no readable go.mod exists at ${ctx.rootDir || 'the repo root'}, so there is no module to pin in`,
       };
     }
+    const tree = goTreeRefusal(ctx.cwd, ctx.rootDir);
+    if (tree !== null) return { kind: 'refused', reason: tree };
     if (goModRequiresDirectly(goMod, ctx.pkg)) {
       return {
         kind: 'refused',
@@ -153,6 +203,9 @@ const goPinTransitive: PinTransitiveProvider = {
       ],
     };
   },
+  // OSV's `Go` ecosystem stores bare X.Y.Z versions; a v-prefixed query
+  // silently matches nothing, and an empty answer would read as clean.
+  osvVersion: stripV,
   execution: () => GO_MOD_EXECUTION,
 };
 
@@ -161,7 +214,13 @@ const goPinTransitive: PinTransitiveProvider = {
  *  the golangci-lint `fixCommand`; Rule 2: one code path each); declare is
  *  the reasoned exemption the doctrine block above explains. */
 export const goRemediation: RemediationSupport = {
-  resyncLockfile: { kind: 'capability', provider: { manifestFiles: ['go.mod'] } },
+  resyncLockfile: {
+    kind: 'capability',
+    // The same tree shapes that defeat the pin defeat the resync: `go mod
+    // tidy` leaves a vendored tree inconsistent and rewrites go.work.sum
+    // outside the envelope under a workspace (one predicate, Rule 2).
+    provider: { manifestFiles: ['go.mod'], refusal: (c) => goTreeRefusal(c.cwd, c.rootDir) },
+  },
   pinTransitive: { kind: 'capability', provider: goPinTransitive },
   declareDependency: {
     kind: 'exemption',

--- a/src/languages/go-remediation.ts
+++ b/src/languages/go-remediation.ts
@@ -1,0 +1,174 @@
+/**
+ * The go ecosystem's remediation capabilities (the pack's `remediation`,
+ * Rule 6, the node-remediation.ts sibling): every Go-modules fact the
+ * recipe executors consume through the capability seam.
+ *
+ * Doctrine notes, kept beside the declarations they explain:
+ *   - go.mod and go.sum are TOOL-OWNED files: dxkit never hand-edits them
+ *     (a text transform cannot maintain go.sum's checksums, and go.mod
+ *     carries directives a naive edit can corrupt). The pin is therefore
+ *     the seam's COMMAND shape: `go get pkg@vX.Y.Z` records an explicit
+ *     require entry at the pinned version, and Go's minimal version
+ *     selection makes the module graph take at least that version. One
+ *     command, both files rewritten consistently, no separate resync.
+ *   - A DIRECT dependency refuses the pin: the honest fix is upgrading
+ *     the declared dependency (the dep-bump lane's job). Direct here
+ *     means a require entry NOT marked `// indirect` in the root go.mod.
+ *   - A module under a `replace` directive refuses: the replacement wins
+ *     over any version pin, so the pin would be inert at best.
+ *   - The version grammar accepts what Go advisories and module proxies
+ *     actually carry: bare x.y.z (the OSV `Go` ecosystem shape) and
+ *     v-prefixed semver, including pseudo-versions
+ *     (v0.0.0-20240101000000-abcdefabcdef, which order by their
+ *     timestamped prerelease segment under the one semver comparator).
+ *   - `declareDependency` is a REASONED EXEMPTION: the go compiler IS the
+ *     import-resolution floor (the pack declares no `resolutionCheck`),
+ *     so no unresolved-import orders are ever minted, and the declare
+ *     recipe's resolution verify would have nothing to re-run; `go get`
+ *     serves it if that floor ever lands for compiled packs.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import type {
+  PinPlanResult,
+  PinTransitiveProvider,
+  PinVersionScheme,
+  RemediationSupport,
+} from './capabilities/remediation';
+import { compareConcreteSemver, isConcreteSemver } from './capabilities/remediation';
+import { GO_MOD_EXECUTION } from './go-install';
+
+/**
+ * A Go module path shape (letters, digits, and `- . _ ~` in slash-separated
+ * segments, each starting alphanumeric). Load-bearing for the Rule 11
+ * argument-injection discipline: the path lands in a `go get` argv, so a
+ * leading dash or whitespace must be rejected before any argv exists. Also
+ * refuses the query forms go itself would interpret (`...`, a leading
+ * `./`), which never name one module.
+ */
+const GO_MODULE_PATH =
+  /^[A-Za-z0-9]([A-Za-z0-9._~-]*[A-Za-z0-9])?(\/[A-Za-z0-9][A-Za-z0-9._~-]*)*$/;
+
+export function isValidGoModulePath(name: string): boolean {
+  return name.length > 0 && name.length <= 500 && GO_MODULE_PATH.test(name) && !name.includes('..');
+}
+
+/** The bare-semver core of a possibly v-prefixed Go version. */
+const stripV = (v: string): string => (v.startsWith('v') ? v.slice(1) : v);
+
+/**
+ * The Go pin-version grammar (Rule 6): OSV's `Go` ecosystem reports bare
+ * x.y.z fixed versions while the module system spells them vX.Y.Z, so both
+ * are concrete here and order under the ONE semver comparator (which also
+ * orders pseudo-versions: their timestamped prerelease segment is
+ * fixed-width, so bytewise identifier order is chronological order).
+ */
+const goPinVersions: PinVersionScheme = {
+  concrete: (v) => isConcreteSemver(stripV(v)),
+  compare: (a, b) => compareConcreteSemver(stripV(a), stripV(b)),
+};
+
+/** Is `pkg` required DIRECTLY by this go.mod (a require entry without the
+ *  `// indirect` marker)? Line-level scan of both the block and one-line
+ *  require forms; refusal-biased (its consumer only ever refuses a pin). */
+function goModRequiresDirectly(goMod: string, pkg: string): boolean {
+  const lines = goMod.split('\n');
+  let inRequire = false;
+  for (const line of lines) {
+    if (/^\s*require\s*\(\s*$/.test(line)) {
+      inRequire = true;
+      continue;
+    }
+    if (inRequire && /^\s*\)\s*$/.test(line)) {
+      inRequire = false;
+      continue;
+    }
+    const entry = inRequire
+      ? line.match(/^\s*(\S+)\s+\S+\s*(\/\/.*)?$/)
+      : line.match(/^\s*require\s+(\S+)\s+\S+\s*(\/\/.*)?$/);
+    if (entry && entry[1] === pkg && !/\/\/\s*indirect\b/.test(entry[2] ?? '')) return true;
+  }
+  return false;
+}
+
+/** Does this go.mod carry a `replace` directive naming `pkg`? */
+function goModReplaces(goMod: string, pkg: string): boolean {
+  const escaped = pkg.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  if (new RegExp(`^\\s*replace\\s+${escaped}(\\s|=)`, 'm').test(goMod)) return true;
+  // The block form: any line inside `replace ( ... )` starting with pkg.
+  const block = goMod.match(/^\s*replace\s*\(([\s\S]*?)^\s*\)/m);
+  return block !== null && new RegExp(`^\\s*${escaped}(\\s|=)`, 'm').test(block[1]);
+}
+
+const goPinTransitive: PinTransitiveProvider = {
+  manifestFiles: ['go.mod'],
+  osvEcosystem: 'Go',
+  versions: goPinVersions,
+  plan(ctx): PinPlanResult {
+    // Rule 11: both tokens land in a `go get` argv verbatim.
+    if (!isValidGoModulePath(ctx.pkg) || !goPinVersions.concrete(ctx.version)) {
+      return {
+        kind: 'refused',
+        reason: `'${ctx.pkg}@${ctx.version}' is not a Go module path + semver version shape dxkit will hand to the go tool`,
+      };
+    }
+    const goModPath = path.join(ctx.cwd, ctx.rootDir, 'go.mod');
+    let goMod: string;
+    try {
+      goMod = fs.readFileSync(goModPath, 'utf8');
+    } catch {
+      return {
+        kind: 'refused',
+        reason: `no readable go.mod exists at ${ctx.rootDir || 'the repo root'}, so there is no module to pin in`,
+      };
+    }
+    if (goModRequiresDirectly(goMod, ctx.pkg)) {
+      return {
+        kind: 'refused',
+        reason:
+          `'${ctx.pkg}' is a direct requirement of this module; the honest fix is upgrading ` +
+          'the declared dependency (the dep-bump lane), not pinning it',
+      };
+    }
+    if (goModReplaces(goMod, ctx.pkg)) {
+      return {
+        kind: 'refused',
+        reason:
+          `'${ctx.pkg}' is under a replace directive in this go.mod, which wins over any ` +
+          'version pin; this pin stays on the agent tier',
+      };
+    }
+    const version = ctx.version.startsWith('v') ? ctx.version : `v${ctx.version}`;
+    const at = ctx.rootDir ? `${ctx.rootDir}/` : '';
+    return {
+      kind: 'command',
+      command: { bin: 'go', args: ['get', `${ctx.pkg}@${version}`] },
+      writes: ['go.mod', 'go.sum'],
+      revert:
+        `remove the '${ctx.pkg}' require entry from ${at}go.mod and run 'go mod tidy' ` +
+        '(tidy drops it once nothing needs the pin)',
+      notes: [
+        `go get records the pin as an explicit require entry in go.mod (marked indirect); ` +
+          'minimal version selection keeps the module graph at or above it',
+      ],
+    };
+  },
+  execution: () => GO_MOD_EXECUTION,
+};
+
+/** The go pack's remediation declarations: resync + pin + lintFix are
+ *  capabilities (the resync rides `goInstallStrategy`, the lint fix rides
+ *  the golangci-lint `fixCommand`; Rule 2: one code path each); declare is
+ *  the reasoned exemption the doctrine block above explains. */
+export const goRemediation: RemediationSupport = {
+  resyncLockfile: { kind: 'capability', provider: { manifestFiles: ['go.mod'] } },
+  pinTransitive: { kind: 'capability', provider: goPinTransitive },
+  declareDependency: {
+    kind: 'exemption',
+    reason:
+      'the go compiler is the import-resolution floor for this pack (no resolutionCheck is ' +
+      'declared), so unresolved-import orders are never minted and a declare could not be ' +
+      'resolution-verified; these orders stay on the agent tier',
+  },
+  lintFix: { kind: 'capability' },
+};

--- a/src/languages/go.ts
+++ b/src/languages/go.ts
@@ -913,6 +913,14 @@ function goChangedPackages(changedFiles: readonly string[]): string[] {
   return [...dirs];
 }
 
+/** The package directory of one repo-relative file, in the `./dir` spec
+ *  shape Go tools take (`.` for a root-level file), the same shape
+ *  `goChangedPackages` emits (Rule 2: one dir-spec convention). */
+function goPackageDir(file: string): string {
+  const dir = path.dirname(file).replace(/\\/g, '/');
+  return dir === '.' ? '.' : `./${dir}`;
+}
+
 /**
  * The Go correctness floor.
  *
@@ -1027,17 +1035,25 @@ const goLintGateProvider: LintGateProvider = {
     };
   },
   // The lint-autofix recipe's fix mode (4.4.7): `golangci-lint run --fix`
-  // scoped to the work order's files. golangci-lint's fixer removes the
-  // issues it fixed from the report (registry pins the v1 flag family), so
-  // the same JSON parse reads only the LEFTOVERS out of the one run: fix
-  // and verify in a single execution, the seam's contract.
+  // scoped to the work order's files' PACKAGE DIRECTORIES. A bare file
+  // argument makes golangci-lint load that one file as the whole package,
+  // so identifiers living in sibling files produce typecheck diagnostics
+  // that would read as net-new leftovers and discard real fixes on any
+  // multi-file package; the directory form type-checks the full package.
+  // Leftovers outside the order's own file are filtered by the recipe's
+  // in-file scoping, and edits outside the envelope are dropped by the
+  // frame's enforcement. golangci-lint's fixer removes the issues it fixed
+  // from the report (registry pins the v1 flag family), so the same JSON
+  // parse reads only the LEFTOVERS out of the one run: fix and verify in a
+  // single execution, the seam's contract.
   fixCommand(ctx) {
     if (ctx.files.length === 0) return null;
     const gl = findTool(TOOL_DEFS['golangci-lint'], ctx.cwd);
     if (!gl.available || !gl.path) return null;
+    const dirs = [...new Set(ctx.files.map((f) => goPackageDir(f)))];
     return {
       bin: gl.path,
-      args: ['run', '--fix', '--out-format', 'json', ...ctx.files],
+      args: ['run', '--fix', '--out-format', 'json', ...dirs],
       parse: { kind: 'structured', label: 'golangci-json', parse: parseGolangciJson },
       expectedExit: 0,
     };

--- a/src/languages/go.ts
+++ b/src/languages/go.ts
@@ -1,5 +1,6 @@
 import { NO_TREE_INVARIANTS } from './capabilities/tree-invariants';
-import { plannedRemediationSupport } from './capabilities/remediation';
+import { goRemediation } from './go-remediation';
+import { goInstallStrategy } from './go-install';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -25,7 +26,10 @@ import type {
   CorrectnessCommand,
   CorrectnessContext,
   CorrectnessProvider,
+  LockfileCheck,
 } from './capabilities/correctness';
+import { lockfileCheckFromStrategy } from './capabilities/correctness';
+import { resolveTolerances } from '../install/tolerances';
 import type { ExecutionRequirement } from '../execution';
 import type {
   CoverageResult,
@@ -956,6 +960,15 @@ const goCorrectnessProvider: CorrectnessProvider = {
     }
     return { label: 'affected-tests', bin: 'go', args: ['test', './...'] };
   },
+
+  // The module-sync floor check derives from the ONE install strategy
+  // through the ONE derivation (`lockfileCheckFromStrategy`), so the check
+  // and the install cannot disagree (Rule 2.30).
+  lockfileCheck(ctx: CorrectnessContext): LockfileCheck | null {
+    const strategy = goInstallStrategy.strategy(ctx.cwd);
+    if (strategy === null) return null;
+    return lockfileCheckFromStrategy(strategy, ctx.tolerances ?? resolveTolerances(ctx.cwd));
+  },
 };
 
 /**
@@ -1009,6 +1022,22 @@ const goLintGateProvider: LintGateProvider = {
       // display format collapses a multi-line diagnostic to its first line
       // and a regex over it silently drops what doesn't fit (Rule 5).
       args: ['run', '--out-format', 'json'],
+      parse: { kind: 'structured', label: 'golangci-json', parse: parseGolangciJson },
+      expectedExit: 0,
+    };
+  },
+  // The lint-autofix recipe's fix mode (4.4.7): `golangci-lint run --fix`
+  // scoped to the work order's files. golangci-lint's fixer removes the
+  // issues it fixed from the report (registry pins the v1 flag family), so
+  // the same JSON parse reads only the LEFTOVERS out of the one run: fix
+  // and verify in a single execution, the seam's contract.
+  fixCommand(ctx) {
+    if (ctx.files.length === 0) return null;
+    const gl = findTool(TOOL_DEFS['golangci-lint'], ctx.cwd);
+    if (!gl.available || !gl.path) return null;
+    return {
+      bin: gl.path,
+      args: ['run', '--fix', '--out-format', 'json', ...ctx.files],
       parse: { kind: 'structured', label: 'golangci-json', parse: parseGolangciJson },
       expectedExit: 0,
     };
@@ -1216,7 +1245,8 @@ export const go: LanguageSupport = {
   },
 
   treeInvariants: NO_TREE_INVARIANTS,
-  remediation: plannedRemediationSupport('go'),
+  installStrategy: goInstallStrategy,
+  remediation: goRemediation,
   correctness: goCorrectnessProvider,
   lintGate: goLintGateProvider,
 

--- a/src/languages/java.ts
+++ b/src/languages/java.ts
@@ -1,5 +1,5 @@
 import { NO_TREE_INVARIANTS } from './capabilities/tree-invariants';
-import { plannedRemediationSupport } from './capabilities/remediation';
+import { jvmRemediation } from './jvm-remediation';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -740,7 +740,15 @@ export const java: LanguageSupport = {
   deepSast: { codeqlLanguage: 'java', snykCode: true, execution: jvmBuildExecution },
 
   treeInvariants: NO_TREE_INVARIANTS,
-  remediation: plannedRemediationSupport('java'),
+  // Dependency-shaped capabilities: the shared JVM exemptions (Rule 2,
+  // jvm-remediation.ts states why). lintFix: the java lint gate is dormant
+  // (lintCommand returns null), so there is no declared fixer to run.
+  remediation: jvmRemediation({
+    kind: 'exemption',
+    reason:
+      'the java lint gate is dormant (no linter command is wired), so there is no declared ' +
+      'fixer to run; these orders stay on the agent tier',
+  }),
   correctness: javaCorrectnessProvider,
   // Lint gate: DORMANT. Java linters (checkstyle/PMD/SpotBugs) run via the build
   // tool with varied, non-line-oriented output (XML/SARIF), so no stable text

--- a/src/languages/jvm-remediation.ts
+++ b/src/languages/jvm-remediation.ts
@@ -1,0 +1,57 @@
+/**
+ * Shared JVM remediation declarations for the Java and Kotlin packs
+ * (CLAUDE.md Rule 2, the jvm-build.ts sibling): both packs run on the same
+ * two build systems (Maven, Gradle), so the dependency-shaped exemptions
+ * are stated once and each pack contributes only its own lint-fix answer.
+ *
+ * Why these are EXEMPTIONS, not capabilities (each names the future
+ * mechanism, per the declared-exemption discipline):
+ *
+ *   - resyncLockfile: Maven has no lockfile at all. Gradle dependency
+ *     locking is a per-configuration OPT-IN whose semantics (which
+ *     configurations are locked, the lock mode) live in the build script;
+ *     a mechanical `--write-locks` run could silently widen or narrow the
+ *     locked set. Until dxkit can read those semantics, a resync here
+ *     cannot be both mechanical and honest.
+ *   - pinTransitive: the JVM pin is a build-file edit
+ *     (`dependencyManagement` in pom.xml, a `constraints` block in
+ *     Gradle), and build files are executable configuration a mechanical
+ *     edit can corrupt in ways the verify-and-discard cannot fully repair
+ *     (the tree is recoverable; a customer's trust in their pom is not).
+ *     The pin graduates if a provably pure build-file edit lands; until
+ *     then the order ships to the agent tier with this reason disclosed.
+ *   - declareDependency: an unresolved JVM import names a package
+ *     namespace, and a namespace does not identify Maven coordinates (a
+ *     groupId:artifactId cannot be derived from it mechanically); the
+ *     compiler is also the resolution floor here (no resolutionCheck), so
+ *     no unresolved-import orders are minted in the first place.
+ */
+import type { RemediationRider, RemediationSupport } from './capabilities/remediation';
+
+export function jvmRemediation(lintFix: RemediationRider): RemediationSupport {
+  return {
+    resyncLockfile: {
+      kind: 'exemption',
+      reason:
+        'maven has no lockfile, and gradle dependency locking is a per-configuration opt-in ' +
+        'whose semantics live in the build script (a mechanical --write-locks run could ' +
+        'silently change the locked set); these orders stay on the agent tier',
+    },
+    pinTransitive: {
+      kind: 'exemption',
+      reason:
+        'a JVM transitive pin is a build-file edit (dependencyManagement in pom.xml, a ' +
+        'gradle constraints block), and build files are executable configuration a ' +
+        'mechanical edit can corrupt; the pin stays on the agent tier until a provably ' +
+        'pure build-file edit exists',
+    },
+    declareDependency: {
+      kind: 'exemption',
+      reason:
+        'an unresolved JVM import names a package namespace, which does not identify maven ' +
+        'coordinates (groupId:artifactId cannot be derived from it mechanically), and the ' +
+        'compiler is the resolution floor here; these orders stay on the agent tier',
+    },
+    lintFix,
+  };
+}

--- a/src/languages/kotlin.ts
+++ b/src/languages/kotlin.ts
@@ -1,5 +1,5 @@
 import { NO_TREE_INVARIANTS } from './capabilities/tree-invariants';
-import { plannedRemediationSupport } from './capabilities/remediation';
+import { jvmRemediation } from './jvm-remediation';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -515,6 +515,22 @@ const kotlinLintGateProvider: LintGateProvider = {
       expectedExit: 0,
     };
   },
+  // The lint-autofix recipe's fix mode (4.4.7): `ktlint -F` scoped to the
+  // work order's files. ktlint's built-in reporters emit only the errors it
+  // could NOT autocorrect when formatting, so the same JSON parse reads the
+  // LEFTOVERS out of the one run: fix and verify in a single execution, the
+  // seam's contract.
+  fixCommand(ctx) {
+    if (ctx.files.length === 0) return null;
+    const ktlint = findTool(TOOL_DEFS.ktlint, ctx.cwd);
+    if (!ktlint.available || !ktlint.path) return null;
+    return {
+      bin: ktlint.path,
+      args: ['-F', '--reporter=json', ...ctx.files],
+      parse: { kind: 'structured', label: 'ktlint-json', parse: parseKtlintJson },
+      expectedExit: 0,
+    };
+  },
   recallInputs(ctx) {
     // ktlint's rule set moves with its version; `.editorconfig` is where a
     // Kotlin repo enables/disables rules and sets the code style, so it is the
@@ -807,7 +823,9 @@ export const kotlin: LanguageSupport = {
   },
 
   treeInvariants: NO_TREE_INVARIANTS,
-  remediation: plannedRemediationSupport('kotlin'),
+  // Dependency-shaped capabilities: the shared JVM exemptions (Rule 2,
+  // jvm-remediation.ts states why). lintFix rides the ktlint fixCommand.
+  remediation: jvmRemediation({ kind: 'capability' }),
   correctness: kotlinCorrectnessProvider,
   lintGate: kotlinLintGateProvider,
 

--- a/src/languages/python-remediation.ts
+++ b/src/languages/python-remediation.ts
@@ -47,6 +47,7 @@ import type {
   RemediationSupport,
 } from './capabilities/remediation';
 import { compareNumericSegments } from './capabilities/remediation';
+import { findTomlTable, foldPackageKey, notToml, tableKeyNames, tomlTableNames } from './toml-text';
 import { pyDistForImport } from './python-dist-names';
 import { pythonInstallStrategy, PYTHON_INSTALL_EXECUTION } from './python-install';
 
@@ -67,54 +68,9 @@ function directDepRefusal(pkg: string): string {
 }
 
 // ── TOML text surgery (line-level, style-preserving, refusal-biased) ──────
-// Documented residual: a TOML multiline string containing a line shaped
-// like a `[table]` header (or a `key = [` array opener) can false-match
-// these line-level scans. The worst outcome is an INERT pin (the entry
-// lands inside the string) or an over-refusal; the recipe's verify
-// (re-audit) then fails and the runner discards the diff, so a corrupt
-// manifest never lands. Full TOML parsing is deliberately not worth that
-// tail risk here.
-
-/** The `[name]` table in `lines`: header index and exclusive body end. */
-function findTomlTable(
-  lines: readonly string[],
-  name: string,
-): { header: number; end: number } | null {
-  const headerRe = new RegExp(`^\\s*\\[${name.replace(/\./g, '\\.')}\\]\\s*(#.*)?$`);
-  for (let i = 0; i < lines.length; i++) {
-    if (!headerRe.test(lines[i])) continue;
-    let end = lines.length;
-    for (let j = i + 1; j < lines.length; j++) {
-      if (/^\s*\[/.test(lines[j])) {
-        end = j;
-        break;
-      }
-    }
-    return { header: i, end };
-  }
-  return null;
-}
-
-/** Every table header name in the document. */
-function tomlTableNames(lines: readonly string[]): string[] {
-  const out: string[] = [];
-  for (const line of lines) {
-    const m = line.match(/^\s*\[\s*([^\]]+?)\s*\]\s*(#.*)?$/);
-    if (m) out.push(m[1]);
-  }
-  return out;
-}
-
-/** Key names declared in one table's body (`name = ...` lines, quoted or
- *  bare), PEP-503 normalized for comparison. */
-function tableKeyNames(lines: readonly string[], table: { header: number; end: number }): string[] {
-  const out: string[] = [];
-  for (let i = table.header + 1; i < table.end; i++) {
-    const m = lines[i].match(/^\s*(?:"([^"]+)"|'([^']+)'|([A-Za-z0-9._-]+))\s*=/);
-    if (m) out.push(m[1] ?? m[2] ?? m[3]);
-  }
-  return out;
-}
+// The generic table/key scans live in `toml-text.ts` (shared with the rust
+// pack, Rule 2); the documented multiline-string residual is stated there.
+// The PEP 508 array scan below stays python-specific.
 
 /** The quoted requirement strings of every `<key> = [ ... ]` array in one
  *  table's body (bracket-balanced across lines), as leading PEP 508 names. */
@@ -140,17 +96,18 @@ function tableArrayRequirementNames(
   return out;
 }
 
-const norm = (n: string): string => n.toLowerCase().replace(/[-_.]+/g, '-');
-
 /** Is `pkg` a direct dependency under PEP 621 (`[project]` dependencies,
  *  `[project.optional-dependencies]` groups, and PEP 735
  *  `[dependency-groups]`, uv's default dev home and what the pack's own
  *  `uv add --dev` writes)? */
 function directInPep621(lines: readonly string[], pkg: string): boolean {
-  const target = norm(pkg);
+  const target = foldPackageKey(pkg);
   for (const name of ['project', 'project.optional-dependencies', 'dependency-groups']) {
     const table = findTomlTable(lines, name);
-    if (table && tableArrayRequirementNames(lines, table).some((n) => norm(n) === target)) {
+    if (
+      table &&
+      tableArrayRequirementNames(lines, table).some((n) => foldPackageKey(n) === target)
+    ) {
       return true;
     }
   }
@@ -159,20 +116,12 @@ function directInPep621(lines: readonly string[], pkg: string): boolean {
 
 /** Is `pkg` declared as a key in any table whose name matches `re`? */
 function directInKeyedTables(lines: readonly string[], re: RegExp, pkg: string): boolean {
-  const target = norm(pkg);
+  const target = foldPackageKey(pkg);
   return tomlTableNames(lines).some((name) => {
     if (!re.test(name)) return false;
     const table = findTomlTable(lines, name);
-    return table !== null && tableKeyNames(lines, table).some((n) => norm(n) === target);
+    return table !== null && tableKeyNames(lines, table).some((n) => foldPackageKey(n) === target);
   });
-}
-
-/** Every transform starts here: a manifest with no table header at all is
- *  not TOML dxkit can edit (garbage, an empty file, JSON). */
-function notToml(text: string, what: string): string | null {
-  return /^\s*\[[^\]]*\]/m.test(text)
-    ? null
-    : `this ${what} does not parse as a TOML manifest, so it cannot be edited`;
 }
 
 // ── the three pin transforms ───────────────────────────────────────────────

--- a/src/languages/rust-install.ts
+++ b/src/languages/rust-install.ts
@@ -1,0 +1,62 @@
+/**
+ * How a Cargo root installs (CLAUDE.md Rule 6), the go-install.ts sibling,
+ * split out of `rust.ts` so the remediation capabilities read the SAME
+ * strategy without a module cycle.
+ *
+ * Doctrine notes, kept beside the declarations they explain:
+ *   - Cargo.lock is the lockfile and cargo itself maintains it; dxkit
+ *     never hand-edits Cargo.toml or Cargo.lock.
+ *   - The frozen install is `cargo fetch --locked`: it downloads exactly
+ *     the locked dependency graph and FAILS when Cargo.lock is missing or
+ *     does not record the manifest, the same refusal CI's `--locked`
+ *     builds ride.
+ *   - The resync is `cargo update --workspace`: the MINIMAL lock rewrite
+ *     (re-resolve so the lockfile records the manifests, holding
+ *     third-party packages at their locked versions where the constraints
+ *     allow). `cargo generate-lockfile` was deliberately not chosen: on
+ *     an existing lockfile it re-resolves everything to the latest
+ *     available versions, churn a lockfile-sync fix must not smuggle in.
+ *   - The sync check is `cargo update --workspace --locked --dry-run`:
+ *     `--locked` asserts the lockfile would not change, `--dry-run` keeps
+ *     even a surprising path from writing, and the minimal `--workspace`
+ *     resolution keeps the answer scoped to "does the lock record the
+ *     manifests". Small output on success (the metadata dump alternative
+ *     can outrun the capture buffer on large workspaces).
+ *   - No ecosystem tolerance exists here: cargo's resolver has no
+ *     peer-check analogue, so no repo-authorized fallbacks are declared.
+ */
+import type { ExecutionRequirement } from '../execution';
+import { declareInstallStrategy } from './capabilities/install-strategy';
+
+/** Lockfile maintenance runs on the ambient Rust toolchain, any host, no
+ *  build (`cargo fetch` / `cargo update` resolve and download only). */
+export const CARGO_LOCK_EXECUTION: ExecutionRequirement = {
+  hosts: ['any'],
+  toolchains: ['rust'],
+  needsBuild: false,
+  buildTarget: 'none',
+  weight: 'cheap',
+};
+
+export const rustInstallStrategy = declareInstallStrategy(
+  [
+    {
+      when: ['Cargo.toml'],
+      strategy: {
+        manager: 'cargo',
+        lockfile: 'Cargo.lock',
+        modes: {
+          frozen: { primary: { bin: 'cargo', args: ['fetch', '--locked'] }, fallbacks: [] },
+          resync: { primary: { bin: 'cargo', args: ['update', '--workspace'] }, fallbacks: [] },
+        },
+        syncCheck: {
+          kind: 'command',
+          command: { bin: 'cargo', args: ['update', '--workspace', '--locked', '--dry-run'] },
+          tolerates: [],
+        },
+        execution: CARGO_LOCK_EXECUTION,
+      },
+    },
+  ],
+  { ciDependencyInstall: false },
+);

--- a/src/languages/rust-remediation.ts
+++ b/src/languages/rust-remediation.ts
@@ -80,6 +80,88 @@ function cargoDeclaresDirectly(cargoToml: string, pkg: string): boolean {
   return false;
 }
 
+/** The `members = [ ... ]` patterns of a root manifest's `[workspace]`
+ *  table (bracket-balanced across lines), or null when no workspace/member
+ *  declaration exists. */
+function workspaceMemberPatterns(lines: readonly string[]): string[] | null {
+  const table = findTomlTable(lines, 'workspace');
+  if (table === null) return null;
+  const out: string[] = [];
+  let started = false;
+  let open = 0;
+  for (let i = table.header + 1; i < table.end; i++) {
+    const line = lines[i];
+    if (!started) {
+      if (!/^\s*members\s*=\s*\[/.test(line)) continue;
+      started = true;
+    }
+    for (const m of line.matchAll(/["']([^"']+)["']/g)) out.push(m[1]);
+    open += (line.match(/\[/g) ?? []).length - (line.match(/\]/g) ?? []).length;
+    if (open <= 0) break;
+  }
+  return started ? out : null;
+}
+
+/**
+ * The workspace-member half of the direct-dependency refusal: the root
+ * manifest alone cannot see a member crate's direct declarations, so a pin
+ * that doctrine says should refuse (a member declares the crate) would
+ * otherwise proceed. Member paths are enumerated only where that is
+ * CONFIDENT (literal paths and the common `prefix/*` glob); any other
+ * pattern refuses outright rather than guess what it matches (refusal
+ * bias: over-refusal is the safe direction, under-enumeration is not).
+ * A missing member directory or manifest contributes nothing (there is no
+ * declaration there to see).
+ */
+function workspaceMemberRefusal(
+  cwd: string,
+  rootDir: string,
+  cargoToml: string,
+  pkg: string,
+): string | null {
+  const patterns = workspaceMemberPatterns(cargoToml.split('\n'));
+  if (patterns === null) return null;
+  const memberDirs: string[] = [];
+  for (const pattern of patterns) {
+    if (!/[*?{}[\]]/.test(pattern)) {
+      memberDirs.push(pattern);
+      continue;
+    }
+    const starDir = pattern.match(/^([^*?{}[\]]+)\/\*$/);
+    if (starDir === null) {
+      return (
+        `this is a cargo workspace whose member pattern '${pattern}' cannot be enumerated ` +
+        'confidently, so member manifests cannot be checked for a direct declaration; ' +
+        'this pin stays on the agent tier'
+      );
+    }
+    let entries: fs.Dirent[] = [];
+    try {
+      entries = fs.readdirSync(path.join(cwd, rootDir, starDir[1]), { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const e of entries) {
+      if (e.isDirectory()) memberDirs.push(`${starDir[1]}/${e.name}`);
+    }
+  }
+  for (const dir of memberDirs) {
+    let text: string;
+    try {
+      text = fs.readFileSync(path.join(cwd, rootDir, dir, 'Cargo.toml'), 'utf8');
+    } catch {
+      continue;
+    }
+    if (cargoDeclaresDirectly(text, pkg)) {
+      return (
+        `'${pkg}' is declared directly by the workspace member ${dir}; the honest fix is ` +
+        'upgrading the declared dependency (the dep-bump lane), not pinning it'
+      );
+    }
+  }
+  return null;
+}
+
 /** A crates.io version shape for the rail (the grammar itself is the
  *  default concrete-semver scheme; this only guards the argv). */
 const CARGO_VERSION = /^[0-9][0-9A-Za-z.+-]*$/;
@@ -114,6 +196,8 @@ const rustPinTransitive: PinTransitiveProvider = {
           'lane), not pinning it',
       };
     }
+    const member = workspaceMemberRefusal(ctx.cwd, ctx.rootDir, cargoToml, ctx.pkg);
+    if (member !== null) return { kind: 'refused', reason: member };
     return {
       kind: 'command',
       command: { bin: 'cargo', args: ['update', '-p', ctx.pkg, '--precise', ctx.version] },

--- a/src/languages/rust-remediation.ts
+++ b/src/languages/rust-remediation.ts
@@ -1,0 +1,155 @@
+/**
+ * The rust ecosystem's remediation capabilities (the pack's `remediation`,
+ * Rule 6, the go-remediation.ts sibling): every cargo fact the recipe
+ * executors consume through the capability seam.
+ *
+ * Doctrine notes, kept beside the declarations they explain:
+ *   - Cargo.toml and Cargo.lock are tool-owned; dxkit never hand-edits
+ *     them. The pin is the seam's COMMAND shape:
+ *     `cargo update -p pkg --precise version` rewrites the Cargo.lock
+ *     entry to exactly the patched version, no manifest change at all
+ *     (the cleanest revert story of any ecosystem here: the pin lives in
+ *     one lockfile line). An incompatible pin (a dependent's version
+ *     requirement the fix does not satisfy) fails cargo loudly, the
+ *     recipe's step fails, and the runner discards the diff; nothing is
+ *     ever guessed past the resolver.
+ *   - A DIRECT dependency refuses the pin: its manifest states the range,
+ *     so the honest fix is upgrading the declared dependency (the
+ *     dep-bump lane). The direct read is a line-level Cargo.toml scan of
+ *     every dependencies-shaped table, including `[workspace.dependencies]`
+ *     and target-specific tables, plus renamed entries (`alias = {
+ *     package = "real-name" }`). Refusal-biased: over-matching only ever
+ *     refuses. A `[patch]` entry naming the crate refuses too (the patch
+ *     wins over the lock).
+ *   - crates.io versions are x.y.z semver, so the default pin grammar
+ *     applies (no declared `versions`).
+ *   - `declareDependency` is a REASONED EXEMPTION: the rust compiler is
+ *     the import-resolution floor (no `resolutionCheck`), so
+ *     unresolved-import orders are never minted and a declare could not
+ *     be resolution-verified; `cargo add` serves it if that floor lands.
+ *   - `lintFix` is a REASONED EXEMPTION: `cargo clippy --fix` rewrites
+ *     whole crates (no file-scoped fix mode, so it cannot honor a work
+ *     order's envelope) and refuses a dirty working tree without
+ *     `--allow-dirty`, a flag dxkit will not pass.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import type {
+  PinPlanResult,
+  PinTransitiveProvider,
+  RemediationSupport,
+} from './capabilities/remediation';
+import { CARGO_LOCK_EXECUTION } from './rust-install';
+import { findTomlTable, foldPackageKey, tableKeyNames, tomlTableNames } from './toml-text';
+
+/** A crates.io package-name shape (alphanumeric start, then letters,
+ *  digits, `-`, `_`). The Rule 11 rail before the name lands in a cargo
+ *  argv: a leading dash would be a flag. */
+const CRATE_NAME = /^[A-Za-z0-9][A-Za-z0-9_-]*$/;
+
+export function isValidCrateName(name: string): boolean {
+  return name.length > 0 && name.length <= 64 && CRATE_NAME.test(name);
+}
+
+/** Dependencies-shaped table names: `[dependencies]`, `[dev-dependencies]`,
+ *  `[build-dependencies]`, `[workspace.dependencies]`, and the
+ *  target-specific `[target.'cfg(...)'.dependencies]` family. */
+const DEP_TABLE = /(^|\.)(dev-|build-)?dependencies$/;
+
+/** Is `pkg` a direct dependency of this Cargo.toml: a key in any
+ *  dependencies-shaped table, or the target of a rename
+ *  (`alias = { package = "pkg" }`), or named by a `[patch]` table? */
+function cargoDeclaresDirectly(cargoToml: string, pkg: string): boolean {
+  const lines = cargoToml.split('\n');
+  const target = foldPackageKey(pkg);
+  for (const name of tomlTableNames(lines)) {
+    const isDepTable = DEP_TABLE.test(name);
+    const isPatchTable = /^patch(\.|$)/.test(name);
+    if (!isDepTable && !isPatchTable) continue;
+    const table = findTomlTable(lines, name);
+    if (table === null) continue;
+    if (tableKeyNames(lines, table).some((n) => foldPackageKey(n) === target)) return true;
+    if (isDepTable) {
+      // A renamed entry declares the real crate through `package = "..."`.
+      for (let i = table.header + 1; i < table.end; i++) {
+        const m = lines[i].match(/\bpackage\s*=\s*["']([^"']+)["']/);
+        if (m && foldPackageKey(m[1]) === target) return true;
+      }
+    }
+  }
+  return false;
+}
+
+/** A crates.io version shape for the rail (the grammar itself is the
+ *  default concrete-semver scheme; this only guards the argv). */
+const CARGO_VERSION = /^[0-9][0-9A-Za-z.+-]*$/;
+
+const rustPinTransitive: PinTransitiveProvider = {
+  manifestFiles: ['Cargo.toml'],
+  osvEcosystem: 'crates.io',
+  plan(ctx): PinPlanResult {
+    // Rule 11: both tokens land in a cargo argv verbatim.
+    if (!isValidCrateName(ctx.pkg) || !CARGO_VERSION.test(ctx.version)) {
+      return {
+        kind: 'refused',
+        reason: `'${ctx.pkg}@${ctx.version}' is not a crate name + version shape dxkit will hand to cargo`,
+      };
+    }
+    const manifestPath = path.join(ctx.cwd, ctx.rootDir, 'Cargo.toml');
+    let cargoToml: string;
+    try {
+      cargoToml = fs.readFileSync(manifestPath, 'utf8');
+    } catch {
+      return {
+        kind: 'refused',
+        reason: `no readable Cargo.toml exists at ${ctx.rootDir || 'the repo root'}, so there is no package to pin in`,
+      };
+    }
+    if (cargoDeclaresDirectly(cargoToml, ctx.pkg)) {
+      return {
+        kind: 'refused',
+        reason:
+          `'${ctx.pkg}' is declared directly in this Cargo.toml (a dependency, rename, or ` +
+          'patch entry); the honest fix is upgrading the declared dependency (the dep-bump ' +
+          'lane), not pinning it',
+      };
+    }
+    return {
+      kind: 'command',
+      command: { bin: 'cargo', args: ['update', '-p', ctx.pkg, '--precise', ctx.version] },
+      writes: ['Cargo.lock'],
+      revert: `run 'cargo update -p ${ctx.pkg}' to release the precise pin in ${
+        ctx.rootDir ? `${ctx.rootDir}/` : ''
+      }Cargo.lock`,
+      notes: [
+        'the precise pin lives in Cargo.lock only (Cargo.toml is unchanged); cargo refuses a ' +
+          "pin that violates a dependent's version requirement, so an incompatible fix fails " +
+          'loudly instead of landing',
+      ],
+    };
+  },
+  execution: () => CARGO_LOCK_EXECUTION,
+};
+
+/** The rust pack's remediation declarations: resync + pin are capabilities
+ *  (the resync rides `rustInstallStrategy`; Rule 2: one code path each);
+ *  declare + lintFix are the reasoned exemptions the doctrine block above
+ *  explains. */
+export const rustRemediation: RemediationSupport = {
+  resyncLockfile: { kind: 'capability', provider: { manifestFiles: ['Cargo.toml'] } },
+  pinTransitive: { kind: 'capability', provider: rustPinTransitive },
+  declareDependency: {
+    kind: 'exemption',
+    reason:
+      'the rust compiler is the import-resolution floor for this pack (no resolutionCheck is ' +
+      'declared), so unresolved-import orders are never minted and a declare could not be ' +
+      'resolution-verified; these orders stay on the agent tier',
+  },
+  lintFix: {
+    kind: 'exemption',
+    reason:
+      "cargo clippy's fix mode rewrites whole crates rather than a work order's files and " +
+      'refuses a dirty working tree without --allow-dirty (a flag dxkit will not pass); ' +
+      'these orders stay on the agent tier',
+  },
+};

--- a/src/languages/rust.ts
+++ b/src/languages/rust.ts
@@ -1,5 +1,6 @@
 import { NO_TREE_INVARIANTS } from './capabilities/tree-invariants';
-import { plannedRemediationSupport } from './capabilities/remediation';
+import { rustRemediation } from './rust-remediation';
+import { rustInstallStrategy } from './rust-install';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -21,7 +22,10 @@ import type {
   CorrectnessCommand,
   CorrectnessContext,
   CorrectnessProvider,
+  LockfileCheck,
 } from './capabilities/correctness';
+import { lockfileCheckFromStrategy } from './capabilities/correctness';
+import { resolveTolerances } from '../install/tolerances';
 import type { ExecutionRequirement } from '../execution';
 import type {
   CoverageResult,
@@ -965,6 +969,15 @@ const rustCorrectnessProvider: CorrectnessProvider = {
     }
     return { label: 'affected-tests', bin: 'cargo', args: ['test'] };
   },
+
+  // The lockfile-sync floor check derives from the ONE install strategy
+  // through the ONE derivation (`lockfileCheckFromStrategy`), so the check
+  // and the install cannot disagree (Rule 2.30).
+  lockfileCheck(ctx: CorrectnessContext): LockfileCheck | null {
+    const strategy = rustInstallStrategy.strategy(ctx.cwd);
+    if (strategy === null) return null;
+    return lockfileCheckFromStrategy(strategy, ctx.tolerances ?? resolveTolerances(ctx.cwd));
+  },
 };
 
 /** clippy `--message-format short` line: `<file>:<line>:<col>: warning|error: <message>`.
@@ -1177,7 +1190,8 @@ export const rust: LanguageSupport = {
   },
 
   treeInvariants: NO_TREE_INVARIANTS,
-  remediation: plannedRemediationSupport('rust'),
+  installStrategy: rustInstallStrategy,
+  remediation: rustRemediation,
   correctness: rustCorrectnessProvider,
   lintGate: rustLintGateProvider,
 

--- a/src/languages/swift.ts
+++ b/src/languages/swift.ts
@@ -1,5 +1,5 @@
 import { NO_TREE_INVARIANTS } from './capabilities/tree-invariants';
-import { plannedRemediationSupport } from './capabilities/remediation';
+import type { RemediationSupport } from './capabilities/remediation';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -628,6 +628,56 @@ function detectSwiftToolchainVersion(cwd: string): string | undefined {
 
 // ─── The pack ───────────────────────────────────────────────────────────────
 
+/**
+ * The swift pack's remediation declarations: four reasoned exemptions
+ * (4.4.7 V3), each naming the future mechanism.
+ *
+ *   - resyncLockfile: SwiftPM has no frozen-install dry-run dxkit can
+ *     verify a Package.resolved resync with (resolution and staleness are
+ *     judged inside the build), so a resync could never confirm its fix.
+ *   - pinTransitive: SwiftPM has no override mechanism for transitive
+ *     dependencies (no resolutions/overrides table); forcing a version
+ *     means declaring the package directly in Package.swift, an
+ *     EXECUTABLE Swift manifest a mechanical edit can corrupt.
+ *   - declareDependency: declaring a package needs that same executable
+ *     manifest edit plus a repository URL an import name does not
+ *     identify (`import NIO` does not name github.com/apple/swift-nio).
+ *   - lintFix: swiftlint's fix mode reports the corrections it APPLIED
+ *     rather than what remains (the phpcbf class), and swiftformat
+ *     answers different rules than the swiftlint gate, so neither can
+ *     fix-and-verify an order's findings in one run.
+ */
+const swiftRemediation: RemediationSupport = {
+  resyncLockfile: {
+    kind: 'exemption',
+    reason:
+      'SwiftPM has no frozen-install dry-run dxkit can verify a Package.resolved resync ' +
+      'with (staleness is judged inside the build), so a resync could never confirm its ' +
+      'fix; these orders stay on the agent tier',
+  },
+  pinTransitive: {
+    kind: 'exemption',
+    reason:
+      'SwiftPM has no override mechanism for transitive dependencies; forcing a version ' +
+      'means editing Package.swift, an executable Swift manifest a mechanical edit can ' +
+      'corrupt; the pin stays on the agent tier',
+  },
+  declareDependency: {
+    kind: 'exemption',
+    reason:
+      'declaring a Swift package needs a Package.swift edit (executable Swift source) plus ' +
+      'a repository URL the import name does not identify; these orders stay on the agent ' +
+      'tier',
+  },
+  lintFix: {
+    kind: 'exemption',
+    reason:
+      "swiftlint's fix mode reports the corrections it applied rather than the findings " +
+      "that remain, so one run cannot both fix and verify an order's findings; these " +
+      'orders stay on the agent tier',
+  },
+};
+
 export const swift: LanguageSupport = {
   id: 'swift',
   displayName: 'Swift',
@@ -730,7 +780,7 @@ export const swift: LanguageSupport = {
   callGraphReliability: 'partial',
 
   treeInvariants: NO_TREE_INVARIANTS,
-  remediation: plannedRemediationSupport('swift'),
+  remediation: swiftRemediation,
   correctness: swiftCorrectnessProvider,
   lintGate: swiftLintGateProvider,
 

--- a/src/languages/toml-text.ts
+++ b/src/languages/toml-text.ts
@@ -1,0 +1,82 @@
+/**
+ * Line-level TOML text scanning shared by the remediation providers that
+ * read or edit TOML manifests (pyproject.toml / Pipfile in the python
+ * pack, Cargo.toml in the rust pack). Moved out of python-remediation.ts
+ * when the rust pack needed the identical scans (Rule 2: one concept, one
+ * code path); behavior is unchanged.
+ *
+ * Documented residual (inherited by every consumer): a TOML multiline
+ * string containing a line shaped like a `[table]` header can false-match
+ * these line-level scans. Consumers bias so the worst outcome is an INERT
+ * edit or an over-refusal, and every recipe's verify then fails and the
+ * runner discards the diff, so a corrupt manifest never lands. Full TOML
+ * parsing is deliberately not worth that tail risk here.
+ */
+
+/** The `[name]` table in `lines`: header index and exclusive body end. */
+export function findTomlTable(
+  lines: readonly string[],
+  name: string,
+): { header: number; end: number } | null {
+  // Escape every regex special: names arrive from tomlTableNames too (a
+  // Cargo target table is `target.'cfg(windows)'.dependencies`), so a bare
+  // dot-escape would build an invalid or mis-matching pattern.
+  const headerRe = new RegExp(
+    `^\\s*\\[${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\]\\s*(#.*)?$`,
+  );
+  for (let i = 0; i < lines.length; i++) {
+    if (!headerRe.test(lines[i])) continue;
+    let end = lines.length;
+    for (let j = i + 1; j < lines.length; j++) {
+      if (/^\s*\[/.test(lines[j])) {
+        end = j;
+        break;
+      }
+    }
+    return { header: i, end };
+  }
+  return null;
+}
+
+/** Every table header name in the document. */
+export function tomlTableNames(lines: readonly string[]): string[] {
+  const out: string[] = [];
+  for (const line of lines) {
+    const m = line.match(/^\s*\[\s*([^\]]+?)\s*\]\s*(#.*)?$/);
+    if (m) out.push(m[1]);
+  }
+  return out;
+}
+
+/** Key names declared in one table's body (`name = ...` lines, quoted or
+ *  bare). */
+export function tableKeyNames(
+  lines: readonly string[],
+  table: { header: number; end: number },
+): string[] {
+  const out: string[] = [];
+  for (let i = table.header + 1; i < table.end; i++) {
+    const m = lines[i].match(/^\s*(?:"([^"]+)"|'([^']+)'|([A-Za-z0-9._-]+))\s*=/);
+    if (m) out.push(m[1] ?? m[2] ?? m[3]);
+  }
+  return out;
+}
+
+/**
+ * Package-name folding for direct-dependency comparisons: lowercase, with
+ * runs of `-` / `_` / `.` folded to one `-`. PyPI names normalize exactly
+ * this way (PEP 503); crates.io treats `-` and `_` as one name for
+ * registration. Folding can only OVER-match, and every consumer uses the
+ * comparison to REFUSE an edit, so the bias points the safe direction.
+ */
+export function foldPackageKey(name: string): string {
+  return name.toLowerCase().replace(/[-_.]+/g, '-');
+}
+
+/** Every transform starts here: a manifest with no table header at all is
+ *  not TOML dxkit can edit (garbage, an empty file, JSON). */
+export function notToml(text: string, what: string): string | null {
+  return /^\s*\[[^\]]*\]/m.test(text)
+    ? null
+    : `this ${what} does not parse as a TOML manifest, so it cannot be edited`;
+}

--- a/src/remediate/recipes/lint-autofix.ts
+++ b/src/remediate/recipes/lint-autofix.ts
@@ -22,7 +22,7 @@ import { parseLocated, parseStructuredLocated } from '../../analyzers/custom-che
 import type { CustomCheckFinding } from '../../analyzers/custom-checks/types';
 import { getLanguage } from '../../languages';
 import type { LanguageId } from '../../languages/types';
-import { exemptionReason, packDeclaration } from './shared';
+import { environmentRefusal, exemptionReason, packDeclaration } from './shared';
 import type { WorkOrder } from '../work-orders/types';
 import type { RecipeExecuteContext, RecipeOutcome } from './types';
 
@@ -58,6 +58,18 @@ export async function executeLintAutofix(
     return { kind: 'refused', reason: exemptionReason(pack, declaration) };
   }
   const provider = getLanguage(pack as LanguageId)?.lintGate;
+  // Rule 20, decided before anything spawns: the gate's declared execution
+  // requirement gates the fix run with a disclosed refusal (the same
+  // doctrine as the dependency recipes), so a missing JDK or Go toolchain
+  // reads as routing, never as a fix failure.
+  if (provider !== undefined) {
+    const envRefusal = environmentRefusal(
+      `the ${pack} pack's linter fix mode`,
+      (cwd) => provider.execution(cwd),
+      ctx.cwd,
+    );
+    if (envRefusal) return envRefusal;
+  }
   const fix = provider?.fixCommand?.({ cwd: ctx.cwd, files: [file] }) ?? null;
   if (fix === null) {
     return {

--- a/src/remediate/recipes/lockfile-sync.ts
+++ b/src/remediate/recipes/lockfile-sync.ts
@@ -52,6 +52,12 @@ export async function executeLockfileSync(
       reason: ambiguousRootReason(declaration.provider.manifestFiles, 'the owning dependency root'),
     };
   }
+  // The pack's per-repo admission check (pure fs reads): a tree shape
+  // where the declared resync would be unsound (a vendored go module, a
+  // go.work workspace) refuses up front instead of burning a run on a
+  // diff the verify or the envelope enforcement must discard.
+  const admission = declaration.provider.refusal?.({ cwd: ctx.cwd, rootDir }) ?? null;
+  if (admission !== null) return { kind: 'refused', reason: admission };
   const rootAbs = path.join(ctx.cwd, rootDir);
   // The pack's install strategy at this root (the ONE install seam): its
   // resync mode is the fix, its lockfile is what the fix rewrites.

--- a/src/remediate/recipes/override-pin.ts
+++ b/src/remediate/recipes/override-pin.ts
@@ -28,6 +28,7 @@ import type { DepAdvisoryEvidence } from '../work-orders/types';
 import {
   ambiguousRootReason,
   environmentRefusal,
+  execStepFailure,
   osvBlockTier,
   packStrategyAt,
   pickPinVersion,
@@ -134,19 +135,38 @@ export async function executeOverridePin(
     }
   }
 
-  // Apply the pack's pure manifest edit: the executor owns the read and the
-  // write; the transform owns the format (and may still refuse: a direct
-  // dependency it only sees with the text in hand).
+  // Apply the pin, per the plan's declared shape:
+  //   - an EDIT plan: the executor owns the read and the write; the pack's
+  //     pure transform owns the format (and may still refuse: a direct
+  //     dependency it only sees with the text in hand). Then the lock
+  //     resync through the pack's install strategy at the same root (the
+  //     ONE install seam; never a second install path).
+  //   - a COMMAND plan (the tool-owned ecosystems): the pack's declared
+  //     command rewrites the dependency files itself, consistently, so no
+  //     separate resync runs.
   const rootAbs = path.join(ctx.cwd, rootDir);
-  const manifestAbs = path.join(rootAbs, plan.edit.file);
-  const edited = plan.edit.transform(fs.readFileSync(manifestAbs, 'utf8'));
-  if ('refused' in edited) return { kind: 'refused', reason: edited.refused };
-  fs.writeFileSync(manifestAbs, edited.text);
+  let changedFiles: string[];
+  if (plan.kind === 'command') {
+    const applied = ctx.exec({ bin: plan.command.bin, args: [...plan.command.args] }, rootAbs);
+    const failure = execStepFailure(
+      'apply-pin',
+      [plan.command.bin, ...plan.command.args].join(' '),
+      applied,
+    );
+    if (failure) return failure;
+    changedFiles = plan.writes.map((f) => (rootDir ? `${rootDir}/${f}` : f));
+  } else {
+    const manifestAbs = path.join(rootAbs, plan.edit.file);
+    const edited = plan.edit.transform(fs.readFileSync(manifestAbs, 'utf8'));
+    if ('refused' in edited) return { kind: 'refused', reason: edited.refused };
+    fs.writeFileSync(manifestAbs, edited.text);
 
-  // The lock resync through the pack's install strategy at the same root
-  // (the ONE install seam; never a second install path).
-  const installFailure = runResyncInstall(strategy, rootAbs, ctx);
-  if (installFailure) return installFailure;
+    const installFailure = runResyncInstall(strategy, rootAbs, ctx);
+    if (installFailure) return installFailure;
+    const manifestPath = rootDir ? `${rootDir}/${plan.edit.file}` : plan.edit.file;
+    const lockPath = rootDir ? `${rootDir}/${strategy.lockfile}` : strategy.lockfile;
+    changedFiles = [manifestPath, lockPath];
+  }
 
   // Verify: the ONE dep-audit dispatch, then "the order's package audits
   // clean": its known advisories are gone and nothing new was minted on it
@@ -170,11 +190,9 @@ export async function executeOverridePin(
         remaining.map((f) => f.id).join(', '),
     };
   }
-  const manifestPath = rootDir ? `${rootDir}/${plan.edit.file}` : plan.edit.file;
-  const lockPath = rootDir ? `${rootDir}/${strategy.lockfile}` : strategy.lockfile;
   return {
     kind: 'applied',
-    changedFiles: [manifestPath, lockPath],
+    changedFiles,
     revert: plan.revert,
     ...(notes.length > 0 ? { notes } : {}),
   };

--- a/src/remediate/recipes/override-pin.ts
+++ b/src/remediate/recipes/override-pin.ts
@@ -119,7 +119,10 @@ export async function executeOverridePin(
   // $0 pre-check: would the pinned version itself carry a block-tier
   // advisory? A null answer (network) is disclosed and the re-audit verify
   // plus the frame's guardrail stay the backstop; it is never read as clean.
-  const known = await ctx.queryOsv(pkg, pin, provider.osvEcosystem);
+  // The pack may declare the form OSV stores (go: bare, no v prefix) so
+  // the pre-check queries what the database actually records.
+  const osvPin = provider.osvVersion?.(pin) ?? pin;
+  const known = await ctx.queryOsv(pkg, osvPin, provider.osvEcosystem);
   if (known === null) {
     notes.push(`OSV pre-check for ${pkg}@${pin} could not be reached; the re-audit verifies`);
   } else {

--- a/src/remediate/recipes/shared.ts
+++ b/src/remediate/recipes/shared.ts
@@ -38,63 +38,16 @@ import type { ExecutionRequirement } from '../../execution';
 import type { WorkOrder } from '../work-orders/types';
 import type { RecipeExecuteContext, RecipeOutcome } from './types';
 
-/** A CONCRETE semver (x.y.z with optional prerelease/build), never a range.
- *  A range-shaped "fixed version" (`>=4.1.0`) cannot be pinned verbatim, so
- *  orders carrying one tier to the agent instead of guessing. */
-const CONCRETE_SEMVER =
-  /^\d+\.\d+\.\d+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/;
-
-export function isConcreteSemver(version: string): boolean {
-  return CONCRETE_SEMVER.test(version);
-}
-
-/** Semver precedence for CONCRETE versions, prerelease rules included: a
- *  release outranks its prereleases (1.2.3 > 1.2.3-beta.1), prerelease
- *  identifiers compare numerically when numeric, bytewise otherwise, and a
- *  longer identifier list wins over its prefix (semver.org section 11). */
-export function compareConcreteSemver(a: string, b: string): number {
-  const parse = (v: string) => {
-    const [core] = v.split('+');
-    const [nums, ...preParts] = core.split('-');
-    return {
-      nums: nums.split('.').map(Number),
-      pre: preParts.length > 0 ? preParts.join('-').split('.') : null,
-    };
-  };
-  const pa = parse(a);
-  const pb = parse(b);
-  for (let i = 0; i < 3; i++) {
-    if (pa.nums[i] !== pb.nums[i]) return pa.nums[i] - pb.nums[i];
-  }
-  if (pa.pre === null && pb.pre === null) return 0;
-  if (pa.pre === null) return 1;
-  if (pb.pre === null) return -1;
-  for (let i = 0; i < Math.max(pa.pre.length, pb.pre.length); i++) {
-    const x = pa.pre[i];
-    const y = pb.pre[i];
-    if (x === undefined) return -1;
-    if (y === undefined) return 1;
-    const xn = /^\d+$/.test(x);
-    const yn = /^\d+$/.test(y);
-    if (xn && yn) {
-      if (Number(x) !== Number(y)) return Number(x) - Number(y);
-    } else if (xn !== yn) {
-      return xn ? -1 : 1; // numeric identifiers rank below alphanumeric
-    } else if (x !== y) {
-      return x < y ? -1 : 1;
-    }
-  }
-  return 0;
-}
-
-/** The default pin-version grammar: the x.y.z semver shape. Packs whose
- *  advisories carry other concrete forms declare their own
- *  `PinVersionScheme` (Rule 6); everything here consumes the scheme, never
- *  the semver helpers directly. */
-export const DEFAULT_PIN_VERSIONS: PinVersionScheme = {
-  concrete: isConcreteSemver,
-  compare: compareConcreteSemver,
-};
+// The concrete-semver shape and the default pin grammar live on the seam
+// itself (`capabilities/remediation.ts`), beside `PinVersionScheme`, so a
+// pack composing on the semver order (go's v-prefixed grammar) reads the
+// ONE comparator. Re-exported here for the recipe tier's consumers.
+import { DEFAULT_PIN_VERSIONS } from '../../languages/capabilities/remediation';
+export {
+  compareConcreteSemver,
+  DEFAULT_PIN_VERSIONS,
+  isConcreteSemver,
+} from '../../languages/capabilities/remediation';
 
 /** The version grammar serving a pin provider: its declared scheme, or the
  *  semver default. The ONE resolution consumed by the registry's `matches`

--- a/test/install/parity.test.ts
+++ b/test/install/parity.test.ts
@@ -223,3 +223,40 @@ describe('template == executor == verifier, per variant', () => {
     }
   });
 });
+
+// The wave-2 strategies (go, rust) declare ZERO fallbacks and are not CI
+// dependency installs, so the per-fallback parity loops above generate no
+// cases for them, a known and bounded vacuity: their command shapes are
+// pinned by the pack declaration tests (test/languages/go-remediation,
+// rust-remediation) and their live recipe path by the e2e go scenario.
+// The degenerate parity property they DO carry is pinned here generically,
+// for every present and future zero-fallback strategy.
+describe('zero-fallback strategies: the degenerate parity (no chain, no retry, no tolerance)', () => {
+  it('a plan with no fallbacks renders exactly its primary and the executor never retries', () => {
+    for (const provider of PROVIDERS) {
+      for (const v of provider.variants()) {
+        const s = v.strategy;
+        const plans = [s.modes.frozen, ...(s.modes.resync ? [s.modes.resync] : [])];
+        for (const plan of plans) {
+          if (plan.fallbacks.length > 0) continue;
+          const argvs: string[] = [];
+          const r = runInstall(
+            plan,
+            '/repo',
+            (cmd) => {
+              argvs.push(text(cmd));
+              return { available: true, code: 1, output: 'any failure shape' };
+            },
+            DEFAULTS,
+          );
+          expect(r.status, `${s.manager}: no silent retry ladder`).toBe('failed');
+          expect(argvs).toEqual([text(plan.primary)]);
+        }
+        if (s.modes.frozen.fallbacks.length === 0) {
+          // The rendered line is the bare primary: nothing to chain.
+          expect(renderInstallLine(v, DEFAULTS)).not.toContain(' || ');
+        }
+      }
+    }
+  });
+});

--- a/test/languages-contract.test.ts
+++ b/test/languages-contract.test.ts
@@ -93,8 +93,10 @@ const RECALL_VERSION_EXEMPT: Readonly<Record<string, string>> = {
  * a strategy.
  */
 const INSTALL_STRATEGY_EXEMPT: Readonly<Record<string, string>> = {
-  go: 'go modules provision on demand (`go build` / `go test` download what go.sum records); there is no separate install step to declare, and the floor commands carry the toolchain.',
-  rust: 'cargo provisions on demand (`cargo build` / `cargo test` resolve Cargo.lock); there is no separate install step to declare.',
+  // go + rust graduated in 4.4.7 V3: their strategies exist for the frozen
+  // verification install and the lockfile-sync recipe (go mod tidy /
+  // cargo update --workspace), even though their builds also provision on
+  // demand.
   csharp:
     'the restore is a build-target decision (`dotnet restore <solution>`), and the pack derives the target and host per repo through its correctness floor (Rule 20); a root-level install declaration would guess a solution.',
   kotlin:
@@ -1268,6 +1270,15 @@ describe('remediation capabilities: a provider or a reasoned exemption, per pack
         if (first.kind === 'refused') {
           expect(first.reason.length).toBeGreaterThan(0);
           expect(first.reason).not.toContain(dir);
+        } else if (first.kind === 'command') {
+          // The tool-owned shape (go / cargo): a real argv, declared
+          // writes, revert prose, no machine path leaking anywhere.
+          expect(first.command.bin.length).toBeGreaterThan(0);
+          expect(first.writes.length).toBeGreaterThan(0);
+          for (const w of first.writes) expect(w).not.toContain('..');
+          expect(first.revert.length).toBeGreaterThan(0);
+          expect(first.revert).not.toContain(dir);
+          expect([first.command.bin, ...first.command.args].join(' ')).not.toContain(dir);
         } else {
           expect(first.edit.file.length).toBeGreaterThan(0);
           expect(first.edit.file).not.toContain('..');

--- a/test/languages/go-remediation.test.ts
+++ b/test/languages/go-remediation.test.ts
@@ -1,0 +1,176 @@
+/**
+ * The go remediation capabilities (4.4.7 V3): the module-path rail, the
+ * v-tolerant pin-version grammar (pseudo-versions included), the pin plan
+ * as a pure decision over real go.mod fixtures (applied / refused /
+ * adversarial), and the install strategy's declared commands. No network,
+ * no spawns: everything here is the pure half of the seam.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { goRemediation, isValidGoModulePath } from '../../src/languages/go-remediation';
+import { goInstallStrategy } from '../../src/languages/go-install';
+import { pickPinVersion } from '../../src/remediate/recipes/shared';
+import type { PinTransitiveProvider } from '../../src/languages/capabilities/remediation';
+
+const pin = (goRemediation.pinTransitive as { provider: PinTransitiveProvider }).provider;
+
+const cleanups: string[] = [];
+afterEach(() => {
+  for (const d of cleanups.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+});
+
+function rootWith(files: Record<string, string>): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-go-remediation-'));
+  cleanups.push(dir);
+  for (const [rel, content] of Object.entries(files)) {
+    fs.writeFileSync(path.join(dir, rel), content);
+  }
+  return dir;
+}
+
+const GO_MOD = `module example.com/app
+
+go 1.22
+
+require (
+\tgithub.com/gin-gonic/gin v1.9.1
+\tgolang.org/x/text v0.3.7 // indirect
+)
+`;
+
+function planAt(goMod: string, pkg = 'golang.org/x/text', version = '0.3.8') {
+  return pin.plan({ cwd: rootWith({ 'go.mod': goMod }), rootDir: '', pkg, version });
+}
+
+describe('the go module-path rail (Rule 11)', () => {
+  it('accepts real module paths, refuses injection and query shapes', () => {
+    expect(isValidGoModulePath('golang.org/x/text')).toBe(true);
+    expect(isValidGoModulePath('github.com/Sirupsen/logrus')).toBe(true);
+    expect(isValidGoModulePath('gopkg.in/yaml.v3')).toBe(true);
+    expect(isValidGoModulePath('-flag')).toBe(false);
+    expect(isValidGoModulePath('--registry=https://evil')).toBe(false);
+    expect(isValidGoModulePath('a b')).toBe(false);
+    expect(isValidGoModulePath('example.com/x/...')).toBe(false);
+    expect(isValidGoModulePath('./relative')).toBe(false);
+    expect(isValidGoModulePath('example.com//x')).toBe(false);
+    expect(isValidGoModulePath('')).toBe(false);
+  });
+});
+
+describe('the go pin-version grammar (v-tolerant semver + pseudo-versions)', () => {
+  const scheme = pin.versions!;
+
+  it('bare and v-prefixed semver are both concrete; ranges and wildcards refuse', () => {
+    expect(scheme.concrete('0.3.8')).toBe(true);
+    expect(scheme.concrete('v0.3.8')).toBe(true);
+    expect(scheme.concrete('v1.2.3+incompatible')).toBe(true);
+    expect(scheme.concrete('v0.0.0-20240101000000-abcdefabcdef')).toBe(true);
+    expect(scheme.concrete('>=0.3.8')).toBe(false);
+    expect(scheme.concrete('v1.x')).toBe(false);
+    expect(scheme.concrete('latest')).toBe(false);
+  });
+
+  it('orders across the v prefix and by pseudo-version timestamp', () => {
+    expect(pickPinVersion(['v0.3.8', '0.3.9'], scheme)).toBe('0.3.9');
+    expect(
+      pickPinVersion(
+        ['v0.0.0-20230101000000-aaaaaaaaaaaa', 'v0.0.0-20240601000000-bbbbbbbbbbbb'],
+        scheme,
+      ),
+    ).toBe('v0.0.0-20240601000000-bbbbbbbbbbbb');
+    // A release outranks the pseudo-versions of its prerelease line.
+    expect(pickPinVersion(['v0.3.8', 'v0.3.8-0.20240101000000-abcdefabcdef'], scheme)).toBe(
+      'v0.3.8',
+    );
+  });
+});
+
+describe('the go pin plan (a pure command decision over go.mod)', () => {
+  it('plans the tool-owned pin: go get pkg@vX.Y.Z, writing go.mod + go.sum', () => {
+    const plan = planAt(GO_MOD);
+    expect(plan.kind).toBe('command');
+    if (plan.kind !== 'command') return;
+    expect(plan.command).toEqual({ bin: 'go', args: ['get', 'golang.org/x/text@v0.3.8'] });
+    expect(plan.writes).toEqual(['go.mod', 'go.sum']);
+    expect(plan.revert).toContain('go mod tidy');
+  });
+
+  it('keeps an already v-prefixed version verbatim', () => {
+    const plan = planAt(GO_MOD, 'golang.org/x/text', 'v0.3.8');
+    expect(plan.kind).toBe('command');
+    if (plan.kind !== 'command') return;
+    expect(plan.command.args).toEqual(['get', 'golang.org/x/text@v0.3.8']);
+  });
+
+  it('refuses a DIRECT requirement (block and one-line forms); an indirect one pins', () => {
+    const direct = planAt(GO_MOD, 'github.com/gin-gonic/gin', '1.9.2');
+    expect(direct.kind).toBe('refused');
+    if (direct.kind === 'refused') expect(direct.reason).toContain('direct requirement');
+    const oneLine = planAt(
+      'module example.com/app\n\ngo 1.22\n\nrequire github.com/gin-gonic/gin v1.9.1\n',
+      'github.com/gin-gonic/gin',
+      '1.9.2',
+    );
+    expect(oneLine.kind).toBe('refused');
+    // The indirect entry is exactly what the pin serves.
+    expect(planAt(GO_MOD).kind).toBe('command');
+  });
+
+  it('refuses a module under a replace directive (the replacement wins)', () => {
+    const replaced = planAt(
+      GO_MOD + '\nreplace golang.org/x/text => ../local-text\n',
+      'golang.org/x/text',
+      '0.3.8',
+    );
+    expect(replaced.kind).toBe('refused');
+    if (replaced.kind === 'refused') expect(replaced.reason).toContain('replace directive');
+    const blockReplaced = planAt(
+      GO_MOD + '\nreplace (\n\tgolang.org/x/text => example.com/fork v0.0.1\n)\n',
+    );
+    expect(blockReplaced.kind).toBe('refused');
+  });
+
+  it('refuses injection-shaped tokens before any argv exists, and a missing go.mod', () => {
+    expect(planAt(GO_MOD, '--registry=evil', '0.3.8').kind).toBe('refused');
+    expect(planAt(GO_MOD, 'golang.org/x/text', '0.3.8 --something').kind).toBe('refused');
+    const noMod = pin.plan({
+      cwd: rootWith({}),
+      rootDir: '',
+      pkg: 'golang.org/x/text',
+      version: '0.3.8',
+    });
+    expect(noMod.kind).toBe('refused');
+  });
+});
+
+describe('the go install strategy (the resync + sync-check spine)', () => {
+  it('declares the module commands: frozen download, tidy resync, tidy -diff check', () => {
+    const dir = rootWith({ 'go.mod': GO_MOD });
+    const strategy = goInstallStrategy.strategy(dir)!;
+    expect(strategy.manager).toBe('gomod');
+    expect(strategy.lockfile).toBe('go.sum');
+    expect(strategy.modes.frozen.primary).toEqual({ bin: 'go', args: ['mod', 'download'] });
+    expect(strategy.modes.resync?.primary).toEqual({ bin: 'go', args: ['mod', 'tidy'] });
+    expect(strategy.syncCheck?.kind).toBe('command');
+    if (strategy.syncCheck?.kind === 'command') {
+      expect(strategy.syncCheck.command.args).toEqual(['mod', 'tidy', '-diff']);
+      // A rejected -diff flag (an EOL toolchain) is named, never read as drift.
+      expect(
+        strategy.syncCheck.classifyFailure?.('flag provided but not defined: -diff'),
+      ).toContain('go 1.23');
+      expect(strategy.syncCheck.classifyFailure?.('go.mod requires go >= 1.22')).toBeNull();
+    }
+    expect(goInstallStrategy.strategy(rootWith({}))).toBeNull();
+  });
+
+  it('declares the reasoned exemption for declare (the compiler is the resolution floor)', () => {
+    expect(goRemediation.declareDependency.kind).toBe('exemption');
+    if (goRemediation.declareDependency.kind === 'exemption') {
+      expect(goRemediation.declareDependency.reason).toContain('resolution floor');
+    }
+    expect(goRemediation.resyncLockfile.kind).toBe('capability');
+    expect(goRemediation.lintFix.kind).toBe('capability');
+  });
+});

--- a/test/languages/go-remediation.test.ts
+++ b/test/languages/go-remediation.test.ts
@@ -9,8 +9,15 @@ import { describe, it, expect, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { goRemediation, isValidGoModulePath } from '../../src/languages/go-remediation';
+import {
+  goRemediation,
+  goTreeRefusal,
+  isValidGoModulePath,
+} from '../../src/languages/go-remediation';
 import { goInstallStrategy } from '../../src/languages/go-install';
+import { lockfileCheckFromStrategy } from '../../src/languages/capabilities/correctness';
+import { executeLockfileCheck } from '../../src/analyzers/correctness/lockfile-check';
+import { defaultResolvedTolerances } from '../../src/install/tolerances';
 import { pickPinVersion } from '../../src/remediate/recipes/shared';
 import type { PinTransitiveProvider } from '../../src/languages/capabilities/remediation';
 
@@ -25,7 +32,9 @@ function rootWith(files: Record<string, string>): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-go-remediation-'));
   cleanups.push(dir);
   for (const [rel, content] of Object.entries(files)) {
-    fs.writeFileSync(path.join(dir, rel), content);
+    const p = path.join(dir, rel);
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, content);
   }
   return dir;
 }
@@ -156,10 +165,12 @@ describe('the go install strategy (the resync + sync-check spine)', () => {
     expect(strategy.syncCheck?.kind).toBe('command');
     if (strategy.syncCheck?.kind === 'command') {
       expect(strategy.syncCheck.command.args).toEqual(['mod', 'tidy', '-diff']);
-      // A rejected -diff flag (an EOL toolchain) is named, never read as drift.
-      expect(
-        strategy.syncCheck.classifyFailure?.('flag provided but not defined: -diff'),
-      ).toContain('go 1.23');
+      // A rejected -diff flag (an EOL toolchain) classifies as a disclosed
+      // SKIP (cannot judge), never as drift and never as a re-worded fail.
+      const classified = strategy.syncCheck.classifyFailure?.(
+        'flag provided but not defined: -diff',
+      );
+      expect(classified).toEqual({ skipped: expect.stringContaining('go 1.23') as string });
       expect(strategy.syncCheck.classifyFailure?.('go.mod requires go >= 1.22')).toBeNull();
     }
     expect(goInstallStrategy.strategy(rootWith({}))).toBeNull();
@@ -172,5 +183,89 @@ describe('the go install strategy (the resync + sync-check spine)', () => {
     }
     expect(goRemediation.resyncLockfile.kind).toBe('capability');
     expect(goRemediation.lintFix.kind).toBe('capability');
+  });
+});
+
+describe('the go tree admission (vendored modules and go.work workspaces refuse)', () => {
+  it('a vendored module refuses the pin AND the resync with the mechanism named', () => {
+    const cwd = rootWith({ 'go.mod': GO_MOD, 'vendor/modules.txt': '# example.com 1\n' });
+    const plan = pin.plan({ cwd, rootDir: '', pkg: 'golang.org/x/text', version: '0.3.8' });
+    expect(plan.kind).toBe('refused');
+    if (plan.kind === 'refused') expect(plan.reason).toContain('vendor');
+    const resync = goRemediation.resyncLockfile;
+    expect(resync.kind).toBe('capability');
+    if (resync.kind === 'capability') {
+      expect(resync.provider.refusal?.({ cwd, rootDir: '' })).toContain('inconsistent vendoring');
+    }
+  });
+
+  it('a go.work workspace refuses, from the module root or any ancestor', () => {
+    const atRoot = rootWith({ 'go.mod': GO_MOD, 'go.work': 'go 1.22\nuse .\n' });
+    expect(goTreeRefusal(atRoot, '')).toContain('go.work');
+    const nested = rootWith({
+      'go.work': 'go 1.22\nuse ./svc\n',
+      'svc/go.mod': GO_MOD,
+    });
+    expect(goTreeRefusal(nested, 'svc')).toContain('go.work.sum');
+    const plan = pin.plan({
+      cwd: nested,
+      rootDir: 'svc',
+      pkg: 'golang.org/x/text',
+      version: '0.3.8',
+    });
+    expect(plan.kind).toBe('refused');
+  });
+
+  it('a plain module (no vendor, no go.work) still plans the pin', () => {
+    const cwd = rootWith({ 'go.mod': GO_MOD });
+    expect(goTreeRefusal(cwd, '')).toBeNull();
+    expect(pin.plan({ cwd, rootDir: '', pkg: 'golang.org/x/text', version: '0.3.8' }).kind).toBe(
+      'command',
+    );
+  });
+});
+
+describe('replace directives across MULTIPLE blocks', () => {
+  it('a module named only in the second replace block still refuses', () => {
+    const twoBlocks =
+      GO_MOD +
+      '\nreplace (\n\texample.com/other => ../other\n)\n\nreplace (\n\tgolang.org/x/text => ../local-text\n)\n';
+    const plan = planAt(twoBlocks, 'golang.org/x/text', '0.3.8');
+    expect(plan.kind).toBe('refused');
+    if (plan.kind === 'refused') expect(plan.reason).toContain('replace directive');
+  });
+});
+
+describe('the OSV query form (bare versions for the Go ecosystem)', () => {
+  it('osvVersion strips the v prefix and leaves bare versions alone', () => {
+    expect(pin.osvVersion?.('v0.3.8')).toBe('0.3.8');
+    expect(pin.osvVersion?.('0.3.8')).toBe('0.3.8');
+    expect(pin.osvVersion?.('v0.0.0-20240101000000-abcdefabcdef')).toBe(
+      '0.0.0-20240101000000-abcdefabcdef',
+    );
+  });
+});
+
+describe('the sync check on an EOL toolchain (cannot judge = a disclosed skip)', () => {
+  it('a rejected -diff flag yields a SKIPPED check (no stale-lockfile order can mint), a real diff still fails', () => {
+    const cwd = rootWith({ 'go.mod': GO_MOD });
+    const strategy = goInstallStrategy.strategy(cwd)!;
+    const check = lockfileCheckFromStrategy(strategy, defaultResolvedTolerances())!;
+    // Orders mint only from status 'fail' (the floor's failed-check set),
+    // so the skipped status is exactly what keeps an unjudgeable tree from
+    // minting a weekly discard-loop order.
+    const oldToolchain = executeLockfileCheck('go', check, cwd, () => ({
+      available: true,
+      code: 2,
+      output: 'flag provided but not defined: -diff',
+    }));
+    expect(oldToolchain.status).toBe('skipped-unavailable');
+    expect(oldToolchain.output).toContain('go 1.23');
+    const drifted = executeLockfileCheck('go', check, cwd, () => ({
+      available: true,
+      code: 1,
+      output: 'diff go.mod.orig go.mod',
+    }));
+    expect(drifted.status).toBe('fail');
   });
 });

--- a/test/languages/php-remediation.test.ts
+++ b/test/languages/php-remediation.test.ts
@@ -48,17 +48,18 @@ describe('pinTransitive: the composer exact-version require pin', () => {
 
   it('refuses a direct dependency (require or require-dev) and non-JSON text', () => {
     const direct = planPin('guzzlehttp/guzzle');
-    if (direct.kind !== 'plan') throw new Error(direct.reason);
+    if (direct.kind !== 'plan')
+      throw new Error(direct.kind === 'refused' ? direct.reason : direct.kind);
     const d = direct.edit.transform(COMPOSER_JSON);
     expect(d).toHaveProperty('refused');
     if ('refused' in d) expect(d.refused).toContain('dep-bump');
 
     const dev = planPin('phpunit/phpunit');
-    if (dev.kind !== 'plan') throw new Error(dev.reason);
+    if (dev.kind !== 'plan') throw new Error(dev.kind === 'refused' ? dev.reason : dev.kind);
     expect(dev.edit.transform(COMPOSER_JSON)).toHaveProperty('refused');
 
     const p = planPin();
-    if (p.kind !== 'plan') throw new Error(p.reason);
+    if (p.kind !== 'plan') throw new Error(p.kind === 'refused' ? p.reason : p.kind);
     for (const garbage of ['', 'not a manifest {', '42', '[]']) {
       expect(p.edit.transform(garbage)).toHaveProperty('refused');
     }

--- a/test/languages/python-remediation.test.ts
+++ b/test/languages/python-remediation.test.ts
@@ -116,7 +116,7 @@ describe('pinTransitive: the uv override surface', () => {
   it('inserts into an existing [tool.uv] section instead of forking a second one', () => {
     const text = `${UV_PYPROJECT}\n[tool.uv]\ndev-dependencies = []\n`;
     const plan = planAt({ 'uv.lock': '', 'pyproject.toml': text });
-    if (plan.kind !== 'plan') throw new Error(plan.reason);
+    if (plan.kind !== 'plan') throw new Error(plan.kind === 'refused' ? plan.reason : plan.kind);
     const out = plan.edit.transform(text);
     if (!('text' in out)) throw new Error(out.refused);
     expect(out.text.match(/\[tool\.uv\]/g)).toHaveLength(1);
@@ -125,14 +125,14 @@ describe('pinTransitive: the uv override surface', () => {
 
   it('refuses a direct dependency, an existing override list, and garbage', () => {
     const plan = planAt({ 'uv.lock': '', 'pyproject.toml': UV_PYPROJECT }, 'requests', '2.32.0');
-    if (plan.kind !== 'plan') throw new Error(plan.reason);
+    if (plan.kind !== 'plan') throw new Error(plan.kind === 'refused' ? plan.reason : plan.kind);
     const direct = plan.edit.transform(UV_PYPROJECT);
     expect(direct).toHaveProperty('refused');
     if ('refused' in direct) expect(direct.refused).toContain('dep-bump');
 
     const withOverride = `${UV_PYPROJECT}\n[tool.uv]\noverride-dependencies = ["x==1.0"]\n`;
     const p2 = planAt({ 'uv.lock': '', 'pyproject.toml': withOverride });
-    if (p2.kind !== 'plan') throw new Error(p2.reason);
+    if (p2.kind !== 'plan') throw new Error(p2.kind === 'refused' ? p2.reason : p2.kind);
     expect(p2.edit.transform(withOverride)).toHaveProperty('refused');
 
     for (const garbage of ['', 'not a manifest {', '42']) {
@@ -145,7 +145,7 @@ describe('pinTransitive: the uv override surface', () => {
 describe('pinTransitive: the poetry + pipenv explicit-entry pins', () => {
   it('poetry: inserts the exact pin under [tool.poetry.dependencies]', () => {
     const plan = planAt({ 'poetry.lock': '', 'pyproject.toml': POETRY_PYPROJECT });
-    if (plan.kind !== 'plan') throw new Error(plan.reason);
+    if (plan.kind !== 'plan') throw new Error(plan.kind === 'refused' ? plan.reason : plan.kind);
     const out = plan.edit.transform(POETRY_PYPROJECT);
     if (!('text' in out)) throw new Error(out.refused);
     expect(out.text).toContain('[tool.poetry.dependencies]\n"urllib3" = "2.5.0"');
@@ -154,16 +154,16 @@ describe('pinTransitive: the poetry + pipenv explicit-entry pins', () => {
 
   it('poetry: refuses a direct dependency (main or group) and a table-less layout', () => {
     const plan = planAt({ 'poetry.lock': '', 'pyproject.toml': POETRY_PYPROJECT }, 'requests');
-    if (plan.kind !== 'plan') throw new Error(plan.reason);
+    if (plan.kind !== 'plan') throw new Error(plan.kind === 'refused' ? plan.reason : plan.kind);
     expect(plan.edit.transform(POETRY_PYPROJECT)).toHaveProperty('refused');
 
     const dev = planAt({ 'poetry.lock': '', 'pyproject.toml': POETRY_PYPROJECT }, 'pytest');
-    if (dev.kind !== 'plan') throw new Error(dev.reason);
+    if (dev.kind !== 'plan') throw new Error(dev.kind === 'refused' ? dev.reason : dev.kind);
     expect(dev.edit.transform(POETRY_PYPROJECT)).toHaveProperty('refused');
 
     const pep621 = '[project]\nname = "fx"\ndependencies = []\n';
     const p = planAt({ 'poetry.lock': '', 'pyproject.toml': pep621 });
-    if (p.kind !== 'plan') throw new Error(p.reason);
+    if (p.kind !== 'plan') throw new Error(p.kind === 'refused' ? p.reason : p.kind);
     const out = p.edit.transform(pep621);
     expect(out).toHaveProperty('refused');
     if ('refused' in out) expect(out.refused).toContain('[tool.poetry.dependencies]');
@@ -171,17 +171,18 @@ describe('pinTransitive: the poetry + pipenv explicit-entry pins', () => {
 
   it('pipenv: inserts the ==pin under [packages], refuses direct entries either section', () => {
     const plan = planAt({ 'Pipfile.lock': '', Pipfile: PIPFILE });
-    if (plan.kind !== 'plan') throw new Error(plan.reason);
+    if (plan.kind !== 'plan') throw new Error(plan.kind === 'refused' ? plan.reason : plan.kind);
     expect(plan.edit.file).toBe('Pipfile');
     const out = plan.edit.transform(PIPFILE);
     if (!('text' in out)) throw new Error(out.refused);
     expect(out.text).toContain('[packages]\n"urllib3" = "==2.5.0"');
 
     const direct = planAt({ 'Pipfile.lock': '', Pipfile: PIPFILE }, 'requests');
-    if (direct.kind !== 'plan') throw new Error(direct.reason);
+    if (direct.kind !== 'plan')
+      throw new Error(direct.kind === 'refused' ? direct.reason : direct.kind);
     expect(direct.edit.transform(PIPFILE)).toHaveProperty('refused');
     const dev = planAt({ 'Pipfile.lock': '', Pipfile: PIPFILE }, 'pytest');
-    if (dev.kind !== 'plan') throw new Error(dev.reason);
+    if (dev.kind !== 'plan') throw new Error(dev.kind === 'refused' ? dev.reason : dev.kind);
     expect(dev.edit.transform(PIPFILE)).toHaveProperty('refused');
   });
 
@@ -191,7 +192,8 @@ describe('pinTransitive: the poetry + pipenv explicit-entry pins', () => {
       'zope.interface',
       '6.4.1',
     );
-    if (applied.kind !== 'plan') throw new Error(applied.reason);
+    if (applied.kind !== 'plan')
+      throw new Error(applied.kind === 'refused' ? applied.reason : applied.kind);
     const out = applied.edit.transform(POETRY_PYPROJECT);
     if (!('text' in out)) throw new Error(out.refused);
     expect(out.text).toContain('[tool.poetry.dependencies]\n"zope.interface" = "6.4.1"');
@@ -203,24 +205,27 @@ describe('pinTransitive: the poetry + pipenv explicit-entry pins', () => {
       'requests = "^2.31"\n"ruamel.yaml" = "^0.18"',
     );
     const direct = planAt({ 'poetry.lock': '', 'pyproject.toml': dotted }, 'ruamel.yaml');
-    if (direct.kind !== 'plan') throw new Error(direct.reason);
+    if (direct.kind !== 'plan')
+      throw new Error(direct.kind === 'refused' ? direct.reason : direct.kind);
     expect(direct.edit.transform(dotted)).toHaveProperty('refused');
 
     const pipenv = planAt({ 'Pipfile.lock': '', Pipfile: PIPFILE }, 'ruamel.yaml', '0.18.6');
-    if (pipenv.kind !== 'plan') throw new Error(pipenv.reason);
+    if (pipenv.kind !== 'plan')
+      throw new Error(pipenv.kind === 'refused' ? pipenv.reason : pipenv.kind);
     const pout = pipenv.edit.transform(PIPFILE);
     if (!('text' in pout)) throw new Error(pout.refused);
     expect(pout.text).toContain('[packages]\n"ruamel.yaml" = "==0.18.6"');
     const pipfileDotted = PIPFILE.replace('requests = "*"', 'requests = "*"\n"ruamel.yaml" = "*"');
     const pdirect = planAt({ 'Pipfile.lock': '', Pipfile: pipfileDotted }, 'ruamel.yaml');
-    if (pdirect.kind !== 'plan') throw new Error(pdirect.reason);
+    if (pdirect.kind !== 'plan')
+      throw new Error(pdirect.kind === 'refused' ? pdirect.reason : pdirect.kind);
     expect(pdirect.edit.transform(pipfileDotted)).toHaveProperty('refused');
   });
 
   it('uv: a PEP 735 [dependency-groups] entry is a direct dependency too (what uv add --dev writes)', () => {
     const withGroups = UV_PYPROJECT + '\n[dependency-groups]\ndev = [\n    "pytest>=8.0",\n]\n';
     const plan = planAt({ 'uv.lock': '', 'pyproject.toml': withGroups }, 'pytest', '8.3.0');
-    if (plan.kind !== 'plan') throw new Error(plan.reason);
+    if (plan.kind !== 'plan') throw new Error(plan.kind === 'refused' ? plan.reason : plan.kind);
     const out = plan.edit.transform(withGroups);
     expect(out).toHaveProperty('refused');
     if ('refused' in out) expect(out.refused).toContain('direct dependency');

--- a/test/languages/ruby-remediation.test.ts
+++ b/test/languages/ruby-remediation.test.ts
@@ -50,23 +50,26 @@ describe('pinTransitive: the Gemfile explicit-entry pin', () => {
 
   it('refuses a directly declared gem (either quote style) and non-Gemfile text', () => {
     const doubleQuoted = planPin('rails');
-    if (doubleQuoted.kind !== 'plan') throw new Error(doubleQuoted.reason);
+    if (doubleQuoted.kind !== 'plan')
+      throw new Error(doubleQuoted.kind === 'refused' ? doubleQuoted.reason : doubleQuoted.kind);
     const d = doubleQuoted.edit.transform(GEMFILE);
     expect(d).toHaveProperty('refused');
     if ('refused' in d) expect(d.refused).toContain('dep-bump');
 
     const singleQuoted = planPin('pg');
-    if (singleQuoted.kind !== 'plan') throw new Error(singleQuoted.reason);
+    if (singleQuoted.kind !== 'plan')
+      throw new Error(singleQuoted.kind === 'refused' ? singleQuoted.reason : singleQuoted.kind);
     expect(singleQuoted.edit.transform(GEMFILE)).toHaveProperty('refused');
 
     // A group-declared gem is still declared.
     const grouped = planPin('rspec-rails');
-    if (grouped.kind !== 'plan') throw new Error(grouped.reason);
+    if (grouped.kind !== 'plan')
+      throw new Error(grouped.kind === 'refused' ? grouped.reason : grouped.kind);
     expect(grouped.edit.transform(GEMFILE)).toHaveProperty('refused');
 
     for (const garbage of ['', 'not a manifest {', '42']) {
       const p = planPin();
-      if (p.kind !== 'plan') throw new Error(p.reason);
+      if (p.kind !== 'plan') throw new Error(p.kind === 'refused' ? p.reason : p.kind);
       expect(p.edit.transform(garbage)).toHaveProperty('refused');
     }
   });

--- a/test/languages/rust-remediation.test.ts
+++ b/test/languages/rust-remediation.test.ts
@@ -23,7 +23,9 @@ function rootWith(files: Record<string, string>): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-rust-remediation-'));
   cleanups.push(dir);
   for (const [rel, content] of Object.entries(files)) {
-    fs.writeFileSync(path.join(dir, rel), content);
+    const p = path.join(dir, rel);
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, content);
   }
   return dir;
 }
@@ -157,5 +159,50 @@ describe('the rust install strategy + declared exemptions', () => {
     if (rustRemediation.lintFix.kind === 'exemption') {
       expect(rustRemediation.lintFix.reason).toContain('--allow-dirty');
     }
+  });
+});
+
+describe('the workspace-member half of the direct-dep refusal', () => {
+  const WS_ROOT = `[workspace]
+members = [
+    "crates/*",
+    "tools/cli",
+]
+
+[workspace.dependencies]
+anyhow = "1.0"
+`;
+
+  it('refuses when a member (literal or glob-enumerated) declares the crate directly', () => {
+    const cwd = rootWith({
+      'Cargo.toml': WS_ROOT,
+      'crates/core/Cargo.toml': '[package]\nname = "core"\n\n[dependencies]\nserde = "1.0"\n',
+      'tools/cli/Cargo.toml': '[package]\nname = "cli"\n\n[dependencies]\nclap = "4.0"\n',
+    });
+    const viaGlob = pin.plan({ cwd, rootDir: '', pkg: 'serde', version: '1.0.200' });
+    expect(viaGlob.kind).toBe('refused');
+    if (viaGlob.kind === 'refused') expect(viaGlob.reason).toContain('crates/core');
+    const viaLiteral = pin.plan({ cwd, rootDir: '', pkg: 'clap', version: '4.5.0' });
+    expect(viaLiteral.kind).toBe('refused');
+    if (viaLiteral.kind === 'refused') expect(viaLiteral.reason).toContain('tools/cli');
+    // A crate no member declares stays pinnable in the workspace.
+    const transitive = pin.plan({ cwd, rootDir: '', pkg: 'smallvec', version: '1.13.2' });
+    expect(transitive.kind).toBe('command');
+  });
+
+  it('refuses outright on a member pattern it cannot enumerate confidently', () => {
+    const cwd = rootWith({
+      'Cargo.toml': '[workspace]\nmembers = ["crates/**"]\n',
+    });
+    const plan = pin.plan({ cwd, rootDir: '', pkg: 'smallvec', version: '1.13.2' });
+    expect(plan.kind).toBe('refused');
+    if (plan.kind === 'refused') expect(plan.reason).toContain('cannot be enumerated');
+  });
+
+  it('a workspace table without members adds nothing beyond the root scan', () => {
+    const cwd = rootWith({
+      'Cargo.toml': '[workspace]\nresolver = "2"\n\n[dependencies]\ntop = "1.0"\n',
+    });
+    expect(pin.plan({ cwd, rootDir: '', pkg: 'smallvec', version: '1.13.2' }).kind).toBe('command');
   });
 });

--- a/test/languages/rust-remediation.test.ts
+++ b/test/languages/rust-remediation.test.ts
@@ -1,0 +1,161 @@
+/**
+ * The rust remediation capabilities (4.4.7 V3): the crate-name rail, the
+ * pin plan as a pure command decision over real Cargo.toml fixtures
+ * (applied / refused / adversarial, rename and workspace tables included),
+ * and the install strategy's declared commands. No network, no spawns.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { isValidCrateName, rustRemediation } from '../../src/languages/rust-remediation';
+import { rustInstallStrategy } from '../../src/languages/rust-install';
+import type { PinTransitiveProvider } from '../../src/languages/capabilities/remediation';
+
+const pin = (rustRemediation.pinTransitive as { provider: PinTransitiveProvider }).provider;
+
+const cleanups: string[] = [];
+afterEach(() => {
+  for (const d of cleanups.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+});
+
+function rootWith(files: Record<string, string>): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-rust-remediation-'));
+  cleanups.push(dir);
+  for (const [rel, content] of Object.entries(files)) {
+    fs.writeFileSync(path.join(dir, rel), content);
+  }
+  return dir;
+}
+
+const CARGO_TOML = `[package]
+name = "fx"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+tokio_util = "0.7"
+
+[dev-dependencies]
+proptest = "1.4"
+`;
+
+function planAt(cargoToml: string, pkg = 'smallvec', version = '1.13.2') {
+  return pin.plan({ cwd: rootWith({ 'Cargo.toml': cargoToml }), rootDir: '', pkg, version });
+}
+
+describe('the crate-name rail (Rule 11)', () => {
+  it('accepts real crate names, refuses injection shapes', () => {
+    expect(isValidCrateName('serde')).toBe(true);
+    expect(isValidCrateName('tokio-util')).toBe(true);
+    expect(isValidCrateName('proc_macro2')).toBe(true);
+    expect(isValidCrateName('-flag')).toBe(false);
+    expect(isValidCrateName('--precise')).toBe(false);
+    expect(isValidCrateName('a b')).toBe(false);
+    expect(isValidCrateName('vendor/pkg')).toBe(false);
+    expect(isValidCrateName('')).toBe(false);
+  });
+});
+
+describe('the cargo pin plan (a pure command decision over Cargo.toml)', () => {
+  it('plans the lockfile-level pin: cargo update -p pkg --precise ver, writing Cargo.lock only', () => {
+    const plan = planAt(CARGO_TOML);
+    expect(plan.kind).toBe('command');
+    if (plan.kind !== 'command') return;
+    expect(plan.command).toEqual({
+      bin: 'cargo',
+      args: ['update', '-p', 'smallvec', '--precise', '1.13.2'],
+    });
+    expect(plan.writes).toEqual(['Cargo.lock']);
+    expect(plan.revert).toContain('cargo update -p smallvec');
+    expect(plan.notes?.join(' ')).toContain('Cargo.lock only');
+  });
+
+  it('refuses a DIRECT dependency across the dependencies-shaped tables, folding - and _', () => {
+    for (const [pkg, version] of [
+      ['serde', '1.0.200'],
+      ['proptest', '1.5.0'],
+      // crates.io folds - and _ into one name; over-matching only refuses.
+      ['tokio-util', '0.7.12'],
+    ] as const) {
+      const refused = planAt(CARGO_TOML, pkg, version);
+      expect(refused.kind, `${pkg} should refuse`).toBe('refused');
+      if (refused.kind === 'refused') expect(refused.reason).toContain('declared directly');
+    }
+  });
+
+  it('refuses a rename target, a workspace dependency, and a patched crate', () => {
+    const renamed = planAt(
+      '[package]\nname = "fx"\n\n[dependencies]\nlogging = { package = "log", version = "0.4" }\n',
+      'log',
+      '0.4.22',
+    );
+    expect(renamed.kind).toBe('refused');
+    const workspace = planAt(
+      '[workspace]\nmembers = ["a"]\n\n[workspace.dependencies]\nserde = "1.0"\n',
+      'serde',
+      '1.0.200',
+    );
+    expect(workspace.kind).toBe('refused');
+    const patched = planAt(
+      CARGO_TOML + '\n[patch.crates-io]\nsmallvec = { path = "../smallvec" }\n',
+      'smallvec',
+      '1.13.2',
+    );
+    expect(patched.kind).toBe('refused');
+    const targetTable = planAt(
+      CARGO_TOML + `\n[target.'cfg(windows)'.dependencies]\nwinapi = "0.3"\n`,
+      'winapi',
+      '0.3.9',
+    );
+    expect(targetTable.kind).toBe('refused');
+  });
+
+  it('refuses injection-shaped tokens and a missing Cargo.toml; a transitive crate pins', () => {
+    expect(planAt(CARGO_TOML, '--precise', '1.0.0').kind).toBe('refused');
+    expect(planAt(CARGO_TOML, 'smallvec', '^1.13').kind).toBe('refused');
+    const noManifest = pin.plan({
+      cwd: rootWith({}),
+      rootDir: '',
+      pkg: 'smallvec',
+      version: '1.13.2',
+    });
+    expect(noManifest.kind).toBe('refused');
+    expect(planAt(CARGO_TOML, 'smallvec', '1.13.2').kind).toBe('command');
+  });
+});
+
+describe('the rust install strategy + declared exemptions', () => {
+  it('declares the cargo commands: frozen fetch --locked, minimal update --workspace resync', () => {
+    const dir = rootWith({ 'Cargo.toml': CARGO_TOML });
+    const strategy = rustInstallStrategy.strategy(dir)!;
+    expect(strategy.manager).toBe('cargo');
+    expect(strategy.lockfile).toBe('Cargo.lock');
+    expect(strategy.modes.frozen.primary).toEqual({ bin: 'cargo', args: ['fetch', '--locked'] });
+    expect(strategy.modes.resync?.primary).toEqual({
+      bin: 'cargo',
+      args: ['update', '--workspace'],
+    });
+    expect(strategy.syncCheck?.kind).toBe('command');
+    if (strategy.syncCheck?.kind === 'command') {
+      expect(strategy.syncCheck.command.args).toEqual([
+        'update',
+        '--workspace',
+        '--locked',
+        '--dry-run',
+      ]);
+    }
+    expect(rustInstallStrategy.strategy(rootWith({}))).toBeNull();
+  });
+
+  it('declares the reasoned exemptions: declare (resolution floor) and lintFix (whole-crate clippy)', () => {
+    expect(rustRemediation.resyncLockfile.kind).toBe('capability');
+    expect(rustRemediation.pinTransitive.kind).toBe('capability');
+    expect(rustRemediation.declareDependency.kind).toBe('exemption');
+    expect(rustRemediation.lintFix.kind).toBe('exemption');
+    if (rustRemediation.lintFix.kind === 'exemption') {
+      expect(rustRemediation.lintFix.reason).toContain('--allow-dirty');
+    }
+  });
+});

--- a/test/languages/wave2-remediation-declarations.test.ts
+++ b/test/languages/wave2-remediation-declarations.test.ts
@@ -6,7 +6,10 @@
  * Every exemption is a full sentence naming why (the declared-exemption
  * discipline: a reason, never silence).
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { getLanguage } from '../../src/languages';
 import {
   REMEDIATION_CAPABILITY_IDS,
@@ -18,6 +21,26 @@ const kotlin = getLanguage('kotlin')!;
 const csharp = getLanguage('csharp')!;
 const swift = getLanguage('swift')!;
 const go = getLanguage('go')!;
+
+const cleanups: string[] = [];
+afterEach(() => {
+  for (const d of cleanups.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+});
+
+/** A fixture repo whose .dxkit/tools.json points findTool at a bin dir of
+ *  fake executables, so fixCommand SHAPES are testable on any host. */
+function repoWithFakeTools(binaries: readonly string[]): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-wave2-decl-'));
+  cleanups.push(dir);
+  const bin = path.join(dir, 'fake-bin');
+  fs.mkdirSync(bin, { recursive: true });
+  for (const b of binaries) {
+    fs.writeFileSync(path.join(bin, b), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+  }
+  fs.mkdirSync(path.join(dir, '.dxkit'), { recursive: true });
+  fs.writeFileSync(path.join(dir, '.dxkit', 'tools.json'), JSON.stringify({ probePaths: [bin] }));
+  return dir;
+}
 
 describe('the shared JVM remediation exemptions (Rule 2 parity)', () => {
   it('java and kotlin state ONE reason per dependency capability', () => {
@@ -34,17 +57,17 @@ describe('the shared JVM remediation exemptions (Rule 2 parity)', () => {
 
   it('kotlin lintFix is a capability riding a real ktlint fixCommand; java stays exempt (dormant gate)', () => {
     expect(kotlin.remediation.lintFix.kind).toBe('capability');
-    const fix = kotlin.lintGate?.fixCommand?.({ cwd: process.cwd(), files: ['src/A.kt'] });
-    // Resolvable only where ktlint is installed; the SHAPE is what the
-    // rider contract pins, so assert it when the tool resolves.
-    if (fix) {
-      expect(fix.bin).toContain('ktlint');
-      expect(fix.args).toContain('-F');
-      expect(fix.args).toContain('src/A.kt');
-      expect(fix.parse.kind).toBe('structured');
-    }
+    // The SHAPE assertions run unconditionally: the fixture plants a fake
+    // ktlint binary on a user-configured probe path (.dxkit/tools.json),
+    // so no host toolchain is needed.
+    const cwd = repoWithFakeTools(['ktlint']);
+    const fix = kotlin.lintGate?.fixCommand?.({ cwd, files: ['src/A.kt'] });
+    expect(fix).toBeDefined();
+    expect(fix!.bin).toContain('ktlint');
+    expect(fix!.args).toEqual(['-F', '--reporter=json', 'src/A.kt']);
+    expect(fix!.parse.kind).toBe('structured');
     // An empty file scope never spawns a fixer.
-    expect(kotlin.lintGate?.fixCommand?.({ cwd: process.cwd(), files: [] })).toBeNull();
+    expect(kotlin.lintGate?.fixCommand?.({ cwd, files: [] })).toBeNull();
 
     expect(java.remediation.lintFix.kind).toBe('exemption');
     if (java.remediation.lintFix.kind === 'exemption') {
@@ -54,14 +77,16 @@ describe('the shared JVM remediation exemptions (Rule 2 parity)', () => {
 });
 
 describe('go lintFix rides golangci-lint --fix (the rider over the gate)', () => {
-  it('the fix command scopes to the order files and reuses the gate parser', () => {
-    const fix = go.lintGate?.fixCommand?.({ cwd: process.cwd(), files: ['pkg/a.go'] });
-    if (fix) {
-      expect(fix.args).toContain('--fix');
-      expect(fix.args).toContain('pkg/a.go');
-      expect(fix.parse.kind).toBe('structured');
-    }
-    expect(go.lintGate?.fixCommand?.({ cwd: process.cwd(), files: [] })).toBeNull();
+  it('the fix command scopes to the files PACKAGE DIRECTORIES and reuses the gate parser', () => {
+    const cwd = repoWithFakeTools(['golangci-lint']);
+    const fix = go.lintGate?.fixCommand?.({ cwd, files: ['pkg/a.go', 'pkg/b.go', 'main.go'] });
+    expect(fix).toBeDefined();
+    // Directory scoping, never bare files: a single named file loads as
+    // the whole package and sibling identifiers read as typecheck
+    // leftovers, discarding real fixes on any multi-file package.
+    expect(fix!.args).toEqual(['run', '--fix', '--out-format', 'json', './pkg', '.']);
+    expect(fix!.parse.kind).toBe('structured');
+    expect(go.lintGate?.fixCommand?.({ cwd, files: [] })).toBeNull();
   });
 });
 

--- a/test/languages/wave2-remediation-declarations.test.ts
+++ b/test/languages/wave2-remediation-declarations.test.ts
@@ -1,0 +1,96 @@
+/**
+ * The wave-2 declaration shapes (4.4.7 V3): the JVM packs share ONE
+ * dependency-exemption set (Rule 2, jvm-remediation.ts), kotlin's lintFix
+ * rides the ktlint fixCommand while java's dormant gate stays exempt, and
+ * csharp + swift carry reasoned exemptions for all four capabilities.
+ * Every exemption is a full sentence naming why (the declared-exemption
+ * discipline: a reason, never silence).
+ */
+import { describe, it, expect } from 'vitest';
+import { getLanguage } from '../../src/languages';
+import {
+  REMEDIATION_CAPABILITY_IDS,
+  type RemediationSupport,
+} from '../../src/languages/capabilities/remediation';
+
+const java = getLanguage('java')!;
+const kotlin = getLanguage('kotlin')!;
+const csharp = getLanguage('csharp')!;
+const swift = getLanguage('swift')!;
+const go = getLanguage('go')!;
+
+describe('the shared JVM remediation exemptions (Rule 2 parity)', () => {
+  it('java and kotlin state ONE reason per dependency capability', () => {
+    for (const capability of ['resyncLockfile', 'pinTransitive', 'declareDependency'] as const) {
+      const j = java.remediation[capability];
+      const k = kotlin.remediation[capability];
+      expect(j.kind).toBe('exemption');
+      expect(k.kind).toBe('exemption');
+      if (j.kind === 'exemption' && k.kind === 'exemption') {
+        expect(j.reason).toBe(k.reason);
+      }
+    }
+  });
+
+  it('kotlin lintFix is a capability riding a real ktlint fixCommand; java stays exempt (dormant gate)', () => {
+    expect(kotlin.remediation.lintFix.kind).toBe('capability');
+    const fix = kotlin.lintGate?.fixCommand?.({ cwd: process.cwd(), files: ['src/A.kt'] });
+    // Resolvable only where ktlint is installed; the SHAPE is what the
+    // rider contract pins, so assert it when the tool resolves.
+    if (fix) {
+      expect(fix.bin).toContain('ktlint');
+      expect(fix.args).toContain('-F');
+      expect(fix.args).toContain('src/A.kt');
+      expect(fix.parse.kind).toBe('structured');
+    }
+    // An empty file scope never spawns a fixer.
+    expect(kotlin.lintGate?.fixCommand?.({ cwd: process.cwd(), files: [] })).toBeNull();
+
+    expect(java.remediation.lintFix.kind).toBe('exemption');
+    if (java.remediation.lintFix.kind === 'exemption') {
+      expect(java.remediation.lintFix.reason).toContain('dormant');
+    }
+  });
+});
+
+describe('go lintFix rides golangci-lint --fix (the rider over the gate)', () => {
+  it('the fix command scopes to the order files and reuses the gate parser', () => {
+    const fix = go.lintGate?.fixCommand?.({ cwd: process.cwd(), files: ['pkg/a.go'] });
+    if (fix) {
+      expect(fix.args).toContain('--fix');
+      expect(fix.args).toContain('pkg/a.go');
+      expect(fix.parse.kind).toBe('structured');
+    }
+    expect(go.lintGate?.fixCommand?.({ cwd: process.cwd(), files: [] })).toBeNull();
+  });
+});
+
+describe('csharp and swift: reasoned exemptions across the board', () => {
+  it.each([
+    ['csharp', csharp.remediation],
+    ['swift', swift.remediation],
+  ] as Array<[string, RemediationSupport]>)('%s states a full reason per capability', (id, r) => {
+    for (const capability of REMEDIATION_CAPABILITY_IDS) {
+      const declaration = r[capability];
+      expect(declaration.kind, `${id}.${String(capability)}`).toBe('exemption');
+      if (declaration.kind === 'exemption') {
+        expect(declaration.reason.length, `${id}.${String(capability)} reason`).toBeGreaterThan(40);
+        expect(declaration.reason).toContain('agent tier');
+      }
+    }
+  });
+
+  it('the reasons name the mechanism gap, not a placeholder', () => {
+    const cs = csharp.remediation;
+    if (cs.pinTransitive.kind === 'exemption') {
+      expect(cs.pinTransitive.reason).toContain('XML');
+    }
+    const sw = swift.remediation;
+    if (sw.pinTransitive.kind === 'exemption') {
+      expect(sw.pinTransitive.reason).toContain('override mechanism');
+    }
+    if (sw.resyncLockfile.kind === 'exemption') {
+      expect(sw.resyncLockfile.reason).toContain('Package.resolved');
+    }
+  });
+});

--- a/test/remediate/e2e-rethink.test.ts
+++ b/test/remediate/e2e-rethink.test.ts
@@ -38,8 +38,25 @@
  *      reason while the pin still lands (`partially-landed`, the rows
  *      naming the dropped order's step).
  */
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { execFileSync } from 'child_process';
+
+// The recipes' Rule 20 gate probes the REAL machine (`currentEnvironment`
+// is not an injected seam), and the go scenario must land on hosts without
+// a Go toolchain (every spawn here is faked anyway). The mock reports every
+// toolchain present and healthy; the gate's own both-direction behavior is
+// pinned by the execution-platform and recipe-playbook tests.
+vi.mock('../../src/execution', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/execution')>();
+  return {
+    ...actual,
+    currentEnvironment: () => ({
+      host: 'linux' as const,
+      hasToolchain: () => true,
+      toolchainProblem: () => null,
+    }),
+  };
+});
 import * as fs from 'fs';
 import * as path from 'path';
 import { runRemediateTask } from '../../src/remediate/run';
@@ -466,6 +483,143 @@ describe('e2e a2: a recipe-only plan lands verified at $0 on a python repo', () 
     expect(uvCalls).toContain('lock');
     expect(git(repo, ['log', '--oneline'])).toContain('lockfile-sync recipe');
     expect(r.ledger).toContain('stale-lockfile:python');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// a3. The compiled-language proof (4.4.7 V3): the same recipe-only $0
+//     landing on a GO repo through the seam's COMMAND plan shape (go owns
+//     go.mod/go.sum, so the pin is `go get`, not a manifest edit). The
+//     driver still throws on contact; every spawn goes through go.
+// ---------------------------------------------------------------------------
+
+const GO_PACKS = [getLanguage('go')!];
+
+const GO_MOD_FIXTURE = `module example.com/app
+
+go 1.22
+
+require golang.org/x/text v0.3.7 // indirect
+`;
+
+/** A go estate: go.mod + go.sum, remediate enabled, the same committed
+ *  baseline + deferred allowlist shape as the node estate. */
+function goEstate(): string {
+  return fixtureRepo({
+    'go.mod': GO_MOD_FIXTURE,
+    'go.sum': 'golang.org/x/text v0.3.7/go.mod h1:aaaa\n',
+    'main.go': 'package main\n\nfunc main() {}\n',
+    '.dxkit/policy.json': policyJson(),
+    '.dxkit/baselines/main.json': baselineJson(),
+    '.dxkit/allowlist.json': DEFERRED_ALLOWLIST,
+  });
+}
+
+/** The go estate's exec fake: `go get` rewrites go.mod + go.sum (the tool
+ *  owns both files, one command); `go mod tidy` rewrites go.sum; the
+ *  `go mod tidy -diff` verify passes cleanly. */
+function goToolExec(repo: string): ReturnType<typeof fakeExec> {
+  return fakeExec((cmd, execCwd) => {
+    const root = execCwd ?? repo;
+    if (cmd.bin !== 'go') return;
+    if (cmd.args[0] === 'get') {
+      fs.appendFileSync(
+        path.join(root, 'go.mod'),
+        'require golang.org/x/text v0.3.8 // indirect\n',
+      );
+      fs.appendFileSync(path.join(root, 'go.sum'), 'golang.org/x/text v0.3.8/go.mod h1:bbbb\n');
+    }
+    if (cmd.args[0] === 'mod' && cmd.args[1] === 'tidy' && !cmd.args.includes('-diff')) {
+      fs.appendFileSync(path.join(root, 'go.sum'), '\n');
+    }
+  });
+}
+
+describe('e2e a3: a recipe-only plan lands verified at $0 on a go repo (the command-plan shape)', () => {
+  it('deferred advisory with a fixed version: the go tool applies its own pin, commits; no resync, no driver', async () => {
+    const repo = goEstate();
+    const { driver, runs } = stubDriver(); // throws on contact
+    const exec = goToolExec(repo);
+    const r = await runOnEstate({
+      repo,
+      packs: GO_PACKS,
+      taskId: 'fix-vulns',
+      driver,
+      exec,
+      scan: [
+        {
+          id: 'GO-2026-0001',
+          package: 'golang.org/x/text',
+          installedVersion: '0.3.7',
+          tool: 'osv-scanner',
+          packId: 'go',
+          severity: 'high',
+          reachable: true,
+          fingerprint: 'dead000011112222',
+          fixedVersion: '0.3.8',
+        },
+      ],
+    });
+
+    expect(runs).toHaveLength(0);
+    expect(r.outcome).toBe('verified');
+    expect(r.recipes?.records.map((rec) => [rec.orderId, rec.outcome.kind])).toEqual([
+      ['dep-advisory:golang.org/x/text', 'applied'],
+    ]);
+    expect(r.envelope).toBeUndefined(); // nothing was spent
+    // The fix is REAL and TOOL-OWNED: one `go get` rewrote both module
+    // files in a commit made by the recipe; no separate resync install ran
+    // and nothing ever spawned npm.
+    const goArgs = exec.calls.filter((c) => c.cmd.bin === 'go').map((c) => c.cmd.args.join(' '));
+    expect(goArgs[0]).toBe('get golang.org/x/text@v0.3.8');
+    // No lock-writing resync followed the pin (the frame's invariant step
+    // may run the non-writing tidy -diff CHECK; a plain tidy never runs).
+    expect(goArgs).not.toContain('mod tidy');
+    expect(exec.calls.every((c) => c.cmd.bin === 'go')).toBe(true);
+    expect(git(repo, ['show', 'HEAD:go.mod'])).toContain('golang.org/x/text v0.3.8');
+    expect(git(repo, ['show', 'HEAD:go.sum'])).toContain('v0.3.8/go.mod');
+    expect(git(repo, ['log', '--oneline'])).toContain('override-pin recipe');
+  });
+
+  it('stale go.sum: lockfile-sync resyncs with go mod tidy, verifies with tidy -diff, commits; zero driver invocations', async () => {
+    const repo = goEstate();
+    const { driver, runs } = stubDriver();
+    const staleEntry: CorrectnessFloorResult = {
+      ran: true,
+      blocks: true,
+      checks: [
+        {
+          pack: 'go',
+          label: LOCKFILE_SYNC_LABEL,
+          bin: 'go',
+          args: ['mod', 'tidy', '-diff'],
+          status: 'fail',
+          output: 'go.mod and go.sum need updates',
+        },
+      ],
+    };
+    const exec = goToolExec(repo);
+    const r = await runOnEstate({
+      repo,
+      packs: GO_PACKS,
+      taskId: 'fix-build',
+      driver,
+      entryFloor: staleEntry,
+      exec,
+    });
+
+    expect(runs).toHaveLength(0);
+    expect(r.outcome).toBe('verified');
+    expect(r.recipes?.records.map((rec) => [rec.orderId, rec.outcome.kind])).toEqual([
+      ['stale-lockfile:go', 'applied'],
+    ]);
+    // The resync AND the verify both went through the go pack's declared
+    // commands (go mod tidy, then go mod tidy -diff).
+    const goArgs = exec.calls.filter((c) => c.cmd.bin === 'go').map((c) => c.cmd.args.join(' '));
+    expect(goArgs).toContain('mod tidy');
+    expect(goArgs).toContain('mod tidy -diff');
+    expect(git(repo, ['log', '--oneline'])).toContain('lockfile-sync recipe');
+    expect(r.ledger).toContain('stale-lockfile:go');
   });
 });
 

--- a/test/remediate/recipes/lint-autofix.test.ts
+++ b/test/remediate/recipes/lint-autofix.test.ts
@@ -138,10 +138,10 @@ describe('lint-autofix recipe', () => {
     const cwd = eslintRepo();
     const { exec } = fakeExec();
     const outcome = await executeLintAutofix(
-      lintOrder('lint:go', 'src/a.ts'),
+      lintOrder('lint:java', 'src/a.ts'),
       makeCtx(cwd, { exec }),
     );
     expect(outcome.kind).toBe('refused');
-    if (outcome.kind === 'refused') expect(outcome.reason).toContain('go');
+    if (outcome.kind === 'refused') expect(outcome.reason).toContain('java');
   });
 });

--- a/test/remediate/recipes/lint-autofix.test.ts
+++ b/test/remediate/recipes/lint-autofix.test.ts
@@ -5,7 +5,23 @@
  * order, pack without a fix mode). Also pins the ts pack's `fixCommand`
  * shape: file-scoped `eslint --fix`, json output, same parser as the gate.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+
+// The Rule 20 gate probes the REAL machine (`currentEnvironment` is not an
+// injected seam). The mock reports the node toolchain present (the
+// typescript fixtures) and everything else absent, so the environment
+// refusal is testable deterministically on any host.
+vi.mock('../../../src/execution', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/execution')>();
+  return {
+    ...actual,
+    currentEnvironment: () => ({
+      host: 'linux' as const,
+      hasToolchain: (id: string) => id === 'node',
+      toolchainProblem: () => null,
+    }),
+  };
+});
 import { executeLintAutofix } from '../../../src/remediate/recipes/lint-autofix';
 import { getLanguage } from '../../../src/languages';
 import { fakeExec, lintFinding, makeCtx, makeOrder, tempRepo } from './helpers';
@@ -143,5 +159,21 @@ describe('lint-autofix recipe', () => {
     );
     expect(outcome.kind).toBe('refused');
     if (outcome.kind === 'refused') expect(outcome.reason).toContain('java');
+  });
+
+  it('Rule 20: an unmet gate execution requirement is a disclosed refusal BEFORE any spawn', async () => {
+    // kotlin's gate needs the jdk toolchain, absent under the env mock.
+    const cwd = eslintRepo();
+    const { exec, calls } = fakeExec();
+    const outcome = await executeLintAutofix(
+      lintOrder('lint:kotlin', 'src/A.kt'),
+      makeCtx(cwd, { exec }),
+    );
+    expect(outcome.kind).toBe('refused');
+    if (outcome.kind === 'refused') {
+      expect(outcome.reason).toContain('cannot run in this environment');
+      expect(outcome.reason).toContain('jdk');
+    }
+    expect(calls).toHaveLength(0);
   });
 });

--- a/test/remediate/recipes/lockfile-sync.test.ts
+++ b/test/remediate/recipes/lockfile-sync.test.ts
@@ -100,7 +100,7 @@ describe('lockfile-sync recipe', () => {
     if (outcome.kind === 'applied') expect(outcome.changedFiles).toEqual(['npm-shrinkwrap.json']);
   });
 
-  it('refuses a pack with no lockfile-sync check to verify with', async () => {
+  it("refuses when the envelope names no root under the pack's manifests (defensive rail)", async () => {
     const cwd = tempRepo({ 'package.json': PKG, 'package-lock.json': '{}' });
     const { exec } = fakeExec();
     const order = makeOrder({
@@ -110,6 +110,25 @@ describe('lockfile-sync recipe', () => {
     });
     const outcome = await executeLockfileSync(order, makeCtx(cwd, { exec }));
     expect(outcome.kind).toBe('refused');
-    if (outcome.kind === 'refused') expect(outcome.reason).toContain('go');
+    if (outcome.kind === 'refused') expect(outcome.reason).toContain('go.mod');
+  });
+
+  it("honors the pack's per-repo admission refusal BEFORE anything runs (go: vendored module)", async () => {
+    const cwd = tempRepo({
+      'go.mod': 'module example.com/app\n\ngo 1.22\n',
+      'go.sum': '',
+      'vendor/modules.txt': '# example.com/dep v1.0.0\n',
+    });
+    const { exec, calls } = fakeExec();
+    const order = makeOrder({
+      id: 'stale-lockfile:go',
+      class: 'stale-lockfile',
+      findings: [floorFinding('go/lockfile-sync', 'go', 'lockfile-sync')],
+      envelope: { paths: ['go.mod', 'go.sum'], manifests: true },
+    });
+    const outcome = await executeLockfileSync(order, makeCtx(cwd, { exec }));
+    expect(outcome.kind).toBe('refused');
+    if (outcome.kind === 'refused') expect(outcome.reason).toContain('inconsistent vendoring');
+    expect(calls).toHaveLength(0);
   });
 });

--- a/test/remediate/recipes/override-pin.test.ts
+++ b/test/remediate/recipes/override-pin.test.ts
@@ -6,8 +6,25 @@
  */
 import * as fs from 'fs';
 import * as path from 'path';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { executeOverridePin } from '../../../src/remediate/recipes/override-pin';
+
+// The Rule 20 gate probes the REAL machine (`currentEnvironment` is not an
+// injected seam), so a test host without the go/rust/php toolchain would
+// turn every applied-path assertion into an environment refusal. The mock
+// reports every toolchain present and healthy; the gate's own behavior is
+// covered by the execution-platform and recipe-playbook tests.
+vi.mock('../../../src/execution', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/execution')>();
+  return {
+    ...actual,
+    currentEnvironment: () => ({
+      host: 'linux' as const,
+      hasToolchain: () => true,
+      toolchainProblem: () => null,
+    }),
+  };
+});
 import {
   compareConcreteSemver,
   isConcreteSemver,
@@ -224,5 +241,86 @@ describe('override-pin recipe', () => {
     );
     expect(outcome.kind).toBe('failed');
     if (outcome.kind === 'failed') expect(outcome.step).toBe('verify-audit');
+  });
+});
+
+describe('override-pin recipe (command plans: the tool-owned ecosystems, 4.4.7 V3)', () => {
+  const GO_MOD =
+    'module example.com/app\n\ngo 1.22\n\nrequire golang.org/x/text v0.3.7 // indirect\n';
+
+  function goOrder(fixedVersion = '0.3.8') {
+    return makeOrder({
+      id: 'dep-advisory:golang.org/x/text',
+      class: 'dep-advisory',
+      findings: [advisoryFinding('f1', 'golang.org/x/text', 'GHSA-gggg', fixedVersion)],
+      envelope: { paths: ['go.mod', 'go.sum'], manifests: true },
+    });
+  }
+
+  it('go: runs the pack-declared `go get` at the root, no separate resync, re-audits clean', async () => {
+    const cwd = tempRepo({ 'go.mod': GO_MOD, 'go.sum': '' });
+    const { exec, calls } = fakeExec();
+    const outcome = await executeOverridePin(goOrder(), makeCtx(cwd, { exec }));
+    expect(outcome.kind).toBe('applied');
+    // The ONE spawn is the tool's own pin command; the tool leaves the tree
+    // consistent, so no lock resync follows.
+    expect(calls.map((c) => [c.cmd.bin, ...c.cmd.args].join(' '))).toEqual([
+      'go get golang.org/x/text@v0.3.8',
+    ]);
+    expect(calls[0].cwd).toBe(cwd);
+    if (outcome.kind === 'applied') {
+      expect(outcome.changedFiles).toEqual(['go.mod', 'go.sum']);
+      expect(outcome.revert).toContain('go mod tidy');
+    }
+  });
+
+  it('go: a failing pin command is a named step failure (diff will be discarded)', async () => {
+    const cwd = tempRepo({ 'go.mod': GO_MOD, 'go.sum': '' });
+    const { exec } = fakeExec((cmd) => {
+      if (cmd.bin === 'go') return { code: 1, output: 'go: module not found' };
+    });
+    const outcome = await executeOverridePin(goOrder(), makeCtx(cwd, { exec }));
+    expect(outcome.kind).toBe('failed');
+    if (outcome.kind === 'failed') {
+      expect(outcome.step).toBe('apply-pin');
+      expect(outcome.output).toContain('module not found');
+    }
+  });
+
+  it('go: the OSV block-tier pre-check refuses BEFORE the command spawns ($0)', async () => {
+    const cwd = tempRepo({ 'go.mod': GO_MOD, 'go.sum': '' });
+    const { exec, calls } = fakeExec();
+    const outcome = await executeOverridePin(
+      goOrder(),
+      makeCtx(cwd, {
+        exec,
+        queryOsv: async () => [{ id: 'GO-2026-9999', database_specific: { severity: 'HIGH' } }],
+      }),
+    );
+    expect(outcome.kind).toBe('refused');
+    if (outcome.kind === 'refused') expect(outcome.reason).toContain('GO-2026-9999');
+    expect(calls).toHaveLength(0);
+  });
+
+  it('rust: runs `cargo update -p --precise` at the root and reports the lockfile as the one write', async () => {
+    const cwd = tempRepo({
+      'Cargo.toml': '[package]\nname = "fx"\n\n[dependencies]\ntop = "1.0"\n',
+      'Cargo.lock': '',
+    });
+    const { exec, calls } = fakeExec();
+    const order = makeOrder({
+      id: 'dep-advisory:smallvec',
+      class: 'dep-advisory',
+      findings: [advisoryFinding('f1', 'smallvec', 'RUSTSEC-2026-0001', '1.13.2')],
+      envelope: { paths: ['Cargo.toml', 'Cargo.lock'], manifests: true },
+    });
+    const outcome = await executeOverridePin(order, makeCtx(cwd, { exec }));
+    expect(outcome.kind).toBe('applied');
+    expect(calls.map((c) => [c.cmd.bin, ...c.cmd.args].join(' '))).toEqual([
+      'cargo update -p smallvec --precise 1.13.2',
+    ]);
+    if (outcome.kind === 'applied') {
+      expect(outcome.changedFiles).toEqual(['Cargo.lock']);
+    }
   });
 });

--- a/test/remediate/recipes/override-pin.test.ts
+++ b/test/remediate/recipes/override-pin.test.ts
@@ -302,6 +302,25 @@ describe('override-pin recipe (command plans: the tool-owned ecosystems, 4.4.7 V
     expect(calls).toHaveLength(0);
   });
 
+  it('go: the OSV pre-check queries the BARE version form the Go ecosystem stores', async () => {
+    const cwd = tempRepo({ 'go.mod': GO_MOD, 'go.sum': '' });
+    const { exec } = fakeExec();
+    const queried: string[] = [];
+    const outcome = await executeOverridePin(
+      goOrder('v0.3.8'),
+      makeCtx(cwd, {
+        exec,
+        queryOsv: async (_pkg, version) => {
+          queried.push(version);
+          return [];
+        },
+      }),
+    );
+    expect(outcome.kind).toBe('applied');
+    // A v-prefixed query would silently match nothing and read as clean.
+    expect(queried).toEqual(['0.3.8']);
+  });
+
   it('rust: runs `cargo update -p --precise` at the root and reports the lockfile as the one write', async () => {
     const cwd = tempRepo({
       'Cargo.toml': '[package]\nname = "fx"\n\n[dependencies]\ntop = "1.0"\n',

--- a/test/remediate/work-orders/recipes.test.ts
+++ b/test/remediate/work-orders/recipes.test.ts
@@ -165,7 +165,7 @@ describe('order-intrinsic feasibility lives in matches (an executor-certain refu
   it('lockfile-sync: a pack without a lockfileCheck, or an ambiguous root, tiers agent', () => {
     const ok = { id: 'stale-lockfile:typescript', class: 'stale-lockfile' as const };
     expect(tierOf({ ...ok, findings: [floorFinding('typescript')] })).toBe('recipe');
-    expect(tierOf({ ...ok, findings: [floorFinding('go')] })).toBe('agent');
+    expect(tierOf({ ...ok, findings: [floorFinding('swift')] })).toBe('agent');
     expect(
       tierOf({
         ...ok,
@@ -191,7 +191,8 @@ describe('order-intrinsic feasibility lives in matches (an executor-certain refu
   it('declare-dependency: an unsupported pack or a flag-shaped specifier tiers agent', () => {
     const ok = { id: 'unresolved-import:typescript:.', class: 'unresolved-import' as const };
     expect(tierOf({ ...ok, findings: [floorFinding('typescript', 'left-pad')] })).toBe('recipe');
-    // A pack whose declaration is a (planned) exemption tiers agent AND the
+    // A pack whose declaration is a reasoned exemption (go: the compiler is
+    // the resolution floor) tiers agent AND the
     // order carries the declared reason for the plan surface (4.4.7 V1).
     const go = assignTier({
       ...draftBase,
@@ -318,6 +319,119 @@ describe('order-intrinsic feasibility lives in matches (an executor-certain refu
     expect(lint('lint:php')).toBe('agent');
   });
 
+  it('the wave-2 packs tier through their declarations (go/rust/jvm/csharp/swift, 4.4.7 V3)', () => {
+    // override-pin: go and rust resolve through their declared manifests.
+    // Go's version grammar accepts bare AND v-prefixed semver plus
+    // pseudo-versions (what Go advisories and module proxies carry); rust
+    // rides the default x.y.z grammar. Ranges refuse everywhere.
+    const pin = (pack: string, paths: string[], fixedVersion: string) =>
+      tierOf({
+        id: 'dep-advisory:p',
+        class: 'dep-advisory' as const,
+        envelope: { paths, manifests: true },
+        findings: [
+          {
+            kind: 'dep-vuln',
+            id: 'a',
+            attribution: 'deferred' as const,
+            evidence: {
+              type: 'dep-vuln' as const,
+              package: 'golang.org/x/text',
+              advisoryId: 'GHSA-2',
+              fixedVersion,
+              pack,
+            },
+          },
+        ],
+      });
+    expect(pin('go', ['go.mod', 'go.sum'], '0.3.8')).toBe('recipe');
+    expect(pin('go', ['go.mod', 'go.sum'], 'v0.3.8')).toBe('recipe');
+    expect(pin('go', ['go.mod', 'go.sum'], 'v0.0.0-20240101000000-abcdefabcdef')).toBe('recipe');
+    expect(pin('go', ['go.mod', 'go.sum'], '>=0.3.8')).toBe('agent');
+    expect(pin('rust', ['Cargo.toml', 'Cargo.lock'], '1.0.195')).toBe('recipe');
+    expect(pin('rust', ['Cargo.toml', 'Cargo.lock'], '^1.0.195')).toBe('agent');
+    // The jvm/csharp/swift pins are declared exemptions, disclosed on the
+    // order with the pack's own reason.
+    for (const [pack, paths, word] of [
+      ['java', ['pom.xml'], 'build-file'],
+      ['kotlin', ['build.gradle.kts'], 'build-file'],
+      ['csharp', ['Directory.Packages.props'], 'XML'],
+      ['swift', ['Package.swift', 'Package.resolved'], 'override mechanism'],
+    ] as const) {
+      const order = assignTier({
+        ...draftBase,
+        id: `dep-advisory:${pack}`,
+        class: 'dep-advisory' as const,
+        envelope: { paths: [...paths], manifests: true },
+        findings: [
+          {
+            kind: 'dep-vuln',
+            id: 'a',
+            attribution: 'deferred' as const,
+            evidence: {
+              type: 'dep-vuln' as const,
+              package: 'p',
+              advisoryId: 'GHSA-3',
+              fixedVersion: '1.2.3',
+              pack,
+            },
+          },
+        ],
+      });
+      expect(order.tier, `${pack} pin should tier agent`).toBe('agent');
+      expect(order.capabilityExemption?.capability).toBe('pinTransitive');
+      expect(order.capabilityExemption?.reason).toContain(word);
+    }
+
+    // lockfile-sync: go and rust declare the capability AND a command sync
+    // check (go mod tidy -diff / cargo update --workspace --locked
+    // --dry-run), so a one-root envelope tiers recipe. The jvm packs carry
+    // the shared declared exemption.
+    const staleOrder = (pack: string, paths: string[]) => ({
+      ...draftBase,
+      id: `stale-lockfile:${pack}`,
+      class: 'stale-lockfile' as const,
+      envelope: { paths, manifests: true },
+      findings: [floorFinding(pack)],
+    });
+    expect(assignTier(staleOrder('go', ['go.mod', 'go.sum'])).tier).toBe('recipe');
+    expect(assignTier(staleOrder('rust', ['Cargo.toml', 'Cargo.lock'])).tier).toBe('recipe');
+    const jvm = assignTier(staleOrder('java', ['pom.xml']));
+    expect(jvm.tier).toBe('agent');
+    expect(jvm.capabilityExemption?.capability).toBe('resyncLockfile');
+    expect(jvm.capabilityExemption?.reason).toContain('maven has no lockfile');
+
+    // declare-dependency: the compiled packs are declared exemptions (the
+    // compiler is the resolution floor), disclosed on the order.
+    const declare = assignTier({
+      ...draftBase,
+      id: 'unresolved-import:rust:.',
+      class: 'unresolved-import' as const,
+      envelope: { paths: ['Cargo.toml', 'Cargo.lock'], manifests: true },
+      findings: [floorFinding('rust', 'serde')],
+    });
+    expect(declare.tier).toBe('agent');
+    expect(declare.capabilityExemption?.capability).toBe('declareDependency');
+    expect(declare.capabilityExemption?.reason).toContain('resolution floor');
+
+    // lint-autofix: golangci-lint and ktlint declare fix modes; clippy
+    // (whole-crate, dirty-tree rules), the dormant java gate, dotnet
+    // format and swiftlint's corrections report are declared exemptions.
+    const lint = (check: string) =>
+      tierOf({
+        id: 'lint-located:src/a',
+        class: 'lint-located' as const,
+        envelope: { paths: ['src/a'], manifests: false },
+        findings: [lintFinding(check)],
+      });
+    expect(lint('lint:go')).toBe('recipe');
+    expect(lint('lint:kotlin')).toBe('recipe');
+    expect(lint('lint:rust')).toBe('agent');
+    expect(lint('lint:java')).toBe('agent');
+    expect(lint('lint:csharp')).toBe('agent');
+    expect(lint('lint:swift')).toBe('agent');
+  });
+
   it('lint-autofix: a user check or a fixCommand-less pack tiers agent; a SLICED order stays recipe (grouped fix)', () => {
     const ok = {
       id: 'lint-located:src/a.ts',
@@ -327,7 +441,7 @@ describe('order-intrinsic feasibility lives in matches (an executor-certain refu
     };
     expect(tierOf({ ...ok, findings: [lintFinding('lint:typescript')] })).toBe('recipe');
     expect(tierOf({ ...ok, findings: [lintFinding('arch-rules')] })).toBe('agent');
-    expect(tierOf({ ...ok, findings: [lintFinding('lint:go')] })).toBe('agent');
+    expect(tierOf({ ...ok, findings: [lintFinding('lint:csharp')] })).toBe('agent');
     // The estate fix: 700 sliced orders on big files must not all go to the
     // agent at full budgets when one file-level --fix answers them.
     expect(


### PR DESCRIPTION
## What

The V3 unit of the remediation language-parity arc: the wave-2 packs (go, rust, java, kotlin, csharp, swift) answer every remediation capability, either with a real provider or a reasoned exemption the plan surface discloses. Nothing is silently absent any more; the generic "planned" exemptions are gone.

### The seam grows one additive shape

Go and cargo own their manifest/lockfile formats, so their honest pin is the tool's own command, not a text edit. `PinPlanResult` gains a third member, the COMMAND plan (`command` + `writes` + `revert`), and the override-pin executor runs it at the owning root through the injected bounded exec, skipping the separate lock resync (the one tool command leaves the tree consistent). Edit plans are untouched. Groundwork moves with no behavior change: the concrete-semver default grammar moves onto the seam beside `PinVersionScheme` (go composes its v-tolerant grammar on the one comparator), and the line-level TOML scans move from python-remediation.ts to `languages/toml-text.ts` so the rust direct-dependency refusal reads the same code path (Rule 2).

### Per-pack matrix

| pack | resyncLockfile | pinTransitive | declareDependency | lintFix |
|---|---|---|---|---|
| go | capability (new `goInstallStrategy`: `go mod download` frozen, `go mod tidy` resync, `go mod tidy -diff` sync check) | capability, command plan: `go get pkg@vX.Y.Z` | exemption: the compiler is the resolution floor, no unresolved-import orders exist to serve | capability: `golangci-lint run --fix` scoped to the order's files |
| rust | capability (new `rustInstallStrategy`: `cargo fetch --locked`, `cargo update --workspace` resync, `--locked --dry-run` sync check) | capability, command plan: `cargo update -p pkg --precise ver` (Cargo.lock only) | exemption: same compiled-pack reason | exemption: clippy `--fix` rewrites whole crates and refuses dirty trees without `--allow-dirty` |
| java | exemption (maven: no lockfile; gradle locking is build-script-governed) | exemption (build-file edit risk) | exemption (namespace does not identify coordinates; compiler is the floor) | exemption (gate is dormant) |
| kotlin | shared jvm exemptions (one declaration, `jvm-remediation.ts`) | shared | shared | capability: `ktlint -F` scoped to the order's files |
| csharp | exemption (per-project opt-in lockfiles + variable csproj basenames the envelope contract cannot name) | exemption (hand-authored XML + same basename gap) | exemption (compiled-pack reason) | exemption (`dotnet format` reports what it changed, not what remains) |
| swift | exemption (no frozen-install dry-run to verify with) | exemption (SPM has no override mechanism) | exemption (executable Package.swift + import does not name a repo URL) | exemption (swiftlint fix reports corrections applied; swiftformat answers different rules than the gate) |

### Judgment calls (deliberate deviations from the design sketch, stated per the brief)

- **The jvm pom edit is an exemption, twice over.** Even a provably pure `dependencyManagement` edit would be unverifiable today: the pin executor requires an install strategy with a lockfile to resync and re-audit against, which maven does not have. A capability that always refuses at runtime would mislead the planner; the exemption names the future mechanism (a provably pure build-file edit) instead. Gradle lockfiles stayed out for the same honesty: locking is a per-configuration opt-in whose semantics live in the build script, so a mechanical `--write-locks` could silently change the locked set.
- **go/rust `declareDependency` is an exemption, not `go get`/`cargo add`.** Compiled packs declare no `resolutionCheck` (the compiler IS that floor), so unresolved-import orders are never minted, and the declare recipe's verify (`runSingleResolutionCheck`) would return null, a certain discard. Declaring a capability that can neither receive an order nor verify one would be fiction; the exemption says exactly that.
- **rust `lintFix` is an exemption despite `cargo fmt`/clippy existing**: clippy's fix mode cannot scope to a work order's files (envelope containment) and refuses dirty trees without `--allow-dirty`, a flag this codebase will not pass; `cargo fmt` answers different rules than the clippy gate (the same reasoning as php's pint exemption in wave 1).
- **swift `resyncLockfile` is an exemption** rather than the sketched Package.resolved resync: SwiftPM has no non-installing frozen dry-run, so the recipe could never confirm its fix (the same certain-discard doctrine that tiers bundler resyncs to the agent).
- **rust resync is `cargo update --workspace`, not `cargo generate-lockfile`**: generate-lockfile re-resolves everything to latest, churn a lockfile-sync fix must not smuggle in.
- **go sync check is `go mod tidy -diff` (go 1.23+)** with a declared classifier that names a rejected `-diff` flag as a toolchain-age condition instead of lockfile drift; every supported Go release carries the flag.
- **go lintFix rides golangci-lint alone (no separate gofmt step)**: the lintFix rider is defined over the gate's own fixer, and gofmt-class formatting is one of golangci-lint's bundled linters; a second fixer would answer rules the gate does not check.

### Graduation side effects (intended)

Adding install strategies to go and rust turns on, for those stacks: the floor's lockfile-sync check (derived through the one `lockfileCheckFromStrategy`), the lane's tree verification installs, the frame's dependency tree invariant, and stale-lockfile work orders. The install parity net covers the new variants automatically.

## How it is tested

- `test/languages/go-remediation.test.ts` + `rust-remediation.test.ts`: pure provider tests on real manifest fixtures, applied / refused / adversarial (direct-dep block and one-line forms, replace/patch/rename/workspace tables, injection shapes, pseudo-version ordering, the strategy command shapes). No network, no spawns.
- `test/languages/wave2-remediation-declarations.test.ts`: the jvm shared-exemption parity (java reason == kotlin reason, Rule 2), kotlin's ktlint `-F` fix shape, java's dormant-gate exemption, csharp + swift full-sentence reasons.
- `test/remediate/recipes/override-pin.test.ts`: the command-plan executor path (one `go get` spawn, no resync, named `apply-pin` failure, OSV block-tier refusal at $0 before any spawn, the cargo `--precise` argv and Cargo.lock-only changedFiles). The file mocks `currentEnvironment` (with a comment saying why): the Rule 20 gate probes the real machine, and the suite must pass on hosts without a go toolchain.
- `test/remediate/work-orders/recipes.test.ts`: the wave-2 planner matrix (see above).
- `test/remediate/e2e-rethink.test.ts` scenario a3: the compiled-language proof pairing wave-1's python scenario: on a real go fixture repo, a deferred advisory lands through the command plan and a stale go.sum lands through `go mod tidy` + the `tidy -diff` verify; the driver throws on contact, zero agent spawns, every spawn through go.
- Existing nets bite for free: languages-contract (the pin-plan contract grew a command-shape branch; go/rust left `INSTALL_STRATEGY_EXEMPT`), install parity (template == executor == floor for the new variants), recipe-playbook.

## Sweep + guardrail

- `npm run typecheck` + `typecheck:test`: clean
- `eslint --max-warnings 0`: clean; `prettier --check .`: clean
- `check-architecture.sh`, `check-docs-coverage.sh`, `check-slop.sh` (base origin/main): pass (slop file-size notes are pre-existing and advisory)
- `npm run build`: clean; `vitest run --coverage`: 436 files, 6670 tests, all passing; coverage 75.66% (threshold 50%), `check-coverage.sh` pass
- `guardrail check --mode ref-based --ref origin/main`: **PASSED** (0 blocking; the flow-gate no-served-truth note is this repo's standing configuration)

## Review focus

- The `PinPlanResult` command member and the override-pin executor branch: is skipping the resync for command plans right in every consumer's eyes (the frame's invariant step still runs the non-writing sync check afterwards)?
- The go direct-requirement and replace-directive scans in `go-remediation.ts` (line-level, refusal-biased) and the cargo direct-dependency scan in `rust-remediation.ts` (dep tables + renames + patch tables, `-`/`_` folding).
- The `currentEnvironment` mocks in the two test files: scoped rationale is in the comments; the gate's both-direction behavior stays pinned elsewhere.
- The exemption prose: each is user-facing plan output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
