### PR TITLE
test(languages,docs): remediation contract nets + generated coverage table (4.4.7 V4)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -321,16 +321,16 @@ imports, testFramework, licenses }`. Each is a `CapabilityProvider`
   declare a real gate; Java ships a dormant provider (no single zero-config
   standalone linter). See CLAUDE.md Rule 17.
 
-- **Remediation capabilities** (4.4.7) — `remediation: RemediationSupport`,
+- **Remediation capabilities** (4.4.7): `remediation: RemediationSupport`,
   REQUIRED: how the deterministic remediation recipes fix findings in this
-  ecosystem. Four declarations, one per recipe — `resyncLockfile` (rides
+  ecosystem. Four declarations, one per recipe: `resyncLockfile` (rides
   `installStrategy` + `correctness.lockfileCheck`; the pack adds only the
   manifest basenames and an optional pure `refusal` hook), `pinTransitive`
   (a pure manifest text edit or a tool-owned pin command, plus the OSV
   ecosystem, an optional version grammar and `osvVersion` projection),
   `declareDependency` (specifier rail, registry version probe + parser,
   install command), and `lintFix` (a rider over `lintGate.fixCommand`).
-  Every entry is either a provider or a reasoned exemption — declare-or-
+  Every entry is either a provider or a reasoned exemption, declare-or-
   exempt, never silence; exempt orders tier to the agent with the reason
   disclosed in `remediate plan`. The scaffold wires
   `plannedRemediationSupport('<id>')` (dormant, compiling); replace entries

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -321,6 +321,29 @@ imports, testFramework, licenses }`. Each is a `CapabilityProvider`
   declare a real gate; Java ships a dormant provider (no single zero-config
   standalone linter). See CLAUDE.md Rule 17.
 
+- **Remediation capabilities** (4.4.7) — `remediation: RemediationSupport`,
+  REQUIRED: how the deterministic remediation recipes fix findings in this
+  ecosystem. Four declarations, one per recipe — `resyncLockfile` (rides
+  `installStrategy` + `correctness.lockfileCheck`; the pack adds only the
+  manifest basenames and an optional pure `refusal` hook), `pinTransitive`
+  (a pure manifest text edit or a tool-owned pin command, plus the OSV
+  ecosystem, an optional version grammar and `osvVersion` projection),
+  `declareDependency` (specifier rail, registry version probe + parser,
+  install command), and `lintFix` (a rider over `lintGate.fixCommand`).
+  Every entry is either a provider or a reasoned exemption — declare-or-
+  exempt, never silence; exempt orders tier to the agent with the reason
+  disclosed in `remediate plan`. The scaffold wires
+  `plannedRemediationSupport('<id>')` (dormant, compiling); replace entries
+  where the ecosystem has the mechanism. Worked examples:
+  `node-remediation.ts` (the full set), `python-remediation.ts` (TOML
+  surgery + custom version grammar), `go-remediation.ts` (tool-owned pin +
+  refusal hook), `jvm-remediation.ts` / `abap.ts` (permanent reasoned
+  exemptions). Contracts in `src/languages/capabilities/remediation.ts`;
+  the contract test pins well-formedness and the recipe playbook pins
+  registry iteration. The per-ecosystem coverage table in
+  `docs/learn/operating-the-lanes.md` is GENERATED from these declarations:
+  after changing them, run `npm run build && npm run docs:remediation-coverage`
+  (`test/remediation-coverage-docs.test.ts` fails until you do).
 - **HTTP flow** (M6) — `httpFlow?: HttpFlowSupport` +
   `treeSitterGrammars?`, the UI→API flow extraction surface. The recipe
   is DECLARATION-ONLY — the one extractor

--- a/docs/learn/operating-the-lanes.md
+++ b/docs/learn/operating-the-lanes.md
@@ -82,6 +82,60 @@ Inside each task run, the frame works the plan in two tiers:
   (infrastructure) keeps the commits on the branch and completes
   `verification-unavailable` instead of destroying or landing anything.
 
+### Recipe coverage per ecosystem
+
+Which orders can go recipe-tier depends on the repo's language packs: each
+pack either declares a provider for a recipe capability or carries a
+reasoned exemption, and exempt orders tier to the agent with the reason
+disclosed in `remediate plan` output. The table below is generated from
+those declarations (a hand-edited copy would drift; edit the pack, then
+run `npm run build && npm run docs:remediation-coverage`).
+
+<!-- BEGIN GENERATED: remediation-coverage (edit the pack declarations, then: npm run build && npm run docs:remediation-coverage) -->
+
+| Pack         | lockfile resync | transitive pin | declare dependency | lint autofix |
+| ------------ | --------------- | -------------- | ------------------ | ------------ |
+| `python`     | recipe          | recipe         | recipe             | recipe       |
+| `typescript` | recipe          | recipe         | recipe             | recipe       |
+| `csharp`     | agent tier      | agent tier     | agent tier         | agent tier   |
+| `go`         | recipe          | recipe         | agent tier         | recipe       |
+| `rust`       | recipe          | recipe         | agent tier         | agent tier   |
+| `kotlin`     | agent tier      | agent tier     | agent tier         | recipe       |
+| `java`       | agent tier      | agent tier     | agent tier         | agent tier   |
+| `ruby`       | recipe          | recipe         | recipe             | recipe       |
+| `swift`      | agent tier      | agent tier     | agent tier         | agent tier   |
+| `php`        | recipe          | recipe         | agent tier         | agent tier   |
+| `abap`       | agent tier      | agent tier     | agent tier         | agent tier   |
+
+The agent-tier cells, in each pack's own words:
+
+- `csharp` lockfile resync: NuGet lockfiles (packages.lock.json) are a per-project opt-in living beside each .csproj, and .NET project manifests have repo-specific basenames the order envelope cannot name by basename; these orders stay on the agent tier until a pattern-aware root derivation exists
+- `csharp` transitive pin: a .NET transitive pin is a .csproj or Directory.Packages.props XML edit, hand-authored XML a mechanical edit can corrupt, and per-project manifests have repo-specific basenames the order envelope cannot name; the pin stays on the agent tier until a provably pure project-file edit exists
+- `csharp` declare dependency: the C# compiler is the import-resolution floor for this pack (no resolutionCheck is declared), so unresolved-import orders are never minted and a declare could not be resolution-verified; these orders stay on the agent tier
+- `csharp` lint autofix: the C# lint gate reads Roslyn analyzer warnings out of dotnet build, and dotnet format reports what it changed rather than the findings that remain, so one run cannot both fix and verify an order's findings; these orders stay on the agent tier
+- `go` declare dependency: the go compiler is the import-resolution floor for this pack (no resolutionCheck is declared), so unresolved-import orders are never minted and a declare could not be resolution-verified; these orders stay on the agent tier
+- `rust` declare dependency: the rust compiler is the import-resolution floor for this pack (no resolutionCheck is declared), so unresolved-import orders are never minted and a declare could not be resolution-verified; these orders stay on the agent tier
+- `rust` lint autofix: cargo clippy's fix mode rewrites whole crates rather than a work order's files and refuses a dirty working tree without --allow-dirty (a flag dxkit will not pass); these orders stay on the agent tier
+- `kotlin` lockfile resync: maven has no lockfile, and gradle dependency locking is a per-configuration opt-in whose semantics live in the build script (a mechanical --write-locks run could silently change the locked set); these orders stay on the agent tier
+- `kotlin` transitive pin: a JVM transitive pin is a build-file edit (dependencyManagement in pom.xml, a gradle constraints block), and build files are executable configuration a mechanical edit can corrupt; the pin stays on the agent tier until a provably pure build-file edit exists
+- `kotlin` declare dependency: an unresolved JVM import names a package namespace, which does not identify maven coordinates (groupId:artifactId cannot be derived from it mechanically), and the compiler is the resolution floor here; these orders stay on the agent tier
+- `java` lockfile resync: maven has no lockfile, and gradle dependency locking is a per-configuration opt-in whose semantics live in the build script (a mechanical --write-locks run could silently change the locked set); these orders stay on the agent tier
+- `java` transitive pin: a JVM transitive pin is a build-file edit (dependencyManagement in pom.xml, a gradle constraints block), and build files are executable configuration a mechanical edit can corrupt; the pin stays on the agent tier until a provably pure build-file edit exists
+- `java` declare dependency: an unresolved JVM import names a package namespace, which does not identify maven coordinates (groupId:artifactId cannot be derived from it mechanically), and the compiler is the resolution floor here; these orders stay on the agent tier
+- `java` lint autofix: the java lint gate is dormant (no linter command is wired), so there is no declared fixer to run; these orders stay on the agent tier
+- `swift` lockfile resync: SwiftPM has no frozen-install dry-run dxkit can verify a Package.resolved resync with (staleness is judged inside the build), so a resync could never confirm its fix; these orders stay on the agent tier
+- `swift` transitive pin: SwiftPM has no override mechanism for transitive dependencies; forcing a version means editing Package.swift, an executable Swift manifest a mechanical edit can corrupt; the pin stays on the agent tier
+- `swift` declare dependency: declaring a Swift package needs a Package.swift edit (executable Swift source) plus a repository URL the import name does not identify; these orders stay on the agent tier
+- `swift` lint autofix: swiftlint's fix mode reports the corrections it applied rather than the findings that remain, so one run cannot both fix and verify an order's findings; these orders stay on the agent tier
+- `php` declare dependency: an unresolved php import names a namespace, and a namespace does not identify a Packagist package (the vendor/package name cannot be derived from it mechanically); these orders stay on the agent tier
+- `php` lint autofix: phpcbf, the phpcs fixer, reports what it fixed rather than what remains, so a single fix run cannot also verify the order's findings are gone; these orders stay on the agent tier
+- `abap` lockfile resync: ABAP has no package manager or lockfile for dxkit to resync
+- `abap` transitive pin: ABAP has no dependency manifest in which a transitive version could be pinned
+- `abap` declare dependency: ABAP has no package registry to declare and install dependencies from
+- `abap` lint autofix: no ABAP linter with a reliable machine autofix is wired as a lint gate yet
+
+<!-- END GENERATED: remediation-coverage -->
+
 Every order's outcome is recorded in the lane's order ledger
 (`.dxkit/lanes/<lane>-<task>.orders.jsonl`): rows ride a landed PR's own
 diff, and a run that lands nothing pushes its rows as a metadata commit on

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "test:integration": "npm run build && vitest run --config vitest.integration.config.ts",
     "docs:commands": "node scripts/generate-command-docs.js",
     "docs:policy-guide": "node scripts/generate-policy-guide.js",
+    "docs:remediation-coverage": "node scripts/generate-remediation-coverage.js",
     "new-lang": "node scripts/scaffold-language.js",
     "dxkit:health": "npm run build && node dist/index.js health",
     "dxkit:guardrail": "npm run build && node dist/index.js guardrail check",

--- a/scripts/generate-remediation-coverage.js
+++ b/scripts/generate-remediation-coverage.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+/**
+ * Rewrite the generated remediation coverage table in
+ * docs/learn/operating-the-lanes.md (4.4.7 V4): which pack supports which
+ * remediation recipe, and the pack-declared exemption reasons, rendered
+ * from the LANGUAGES registry. Run after changing a pack's remediation
+ * declarations (or adding a pack):
+ *
+ *   npm run build && npm run docs:remediation-coverage
+ *
+ * test/remediation-coverage-docs.test.ts pins the committed guide against
+ * a fresh render, so forgetting this step fails CI with a pointer here.
+ */
+const { existsSync, readFileSync, writeFileSync } = require('node:fs');
+const { execFileSync } = require('node:child_process');
+const path = require('node:path');
+
+const root = path.join(__dirname, '..');
+const distModule = path.join(root, 'dist', 'discovery', 'remediation-coverage-tables.js');
+if (!existsSync(distModule)) {
+  console.error(
+    'dist/discovery/remediation-coverage-tables.js not found: run `npm run build` first.', // slop-ok: build script
+  );
+  process.exit(1);
+}
+
+const { replaceRemediationCoverage } = require(distModule);
+
+const guide = path.join(root, 'docs', 'learn', 'operating-the-lanes.md');
+writeFileSync(guide, replaceRemediationCoverage(readFileSync(guide, 'utf8')));
+execFileSync('npx', ['prettier', '--write', 'docs/learn/operating-the-lanes.md'], {
+  cwd: root,
+  stdio: 'inherit',
+});
+console.log('✓ remediation coverage table regenerated from the pack declarations'); // slop-ok: build script

--- a/scripts/scaffold-language.js
+++ b/scripts/scaffold-language.js
@@ -708,10 +708,19 @@ export const ${id}: LanguageSupport = {
   // (orders tier to the agent with the reason disclosed in plan output), and
   // the pack compiles (the same optional-then-filled arc as correctness).
   // TODO(${id}): replace entries with real providers where the ecosystem has
-  // the mechanism; see src/languages/node-remediation.ts for the worked
-  // example and src/languages/capabilities/remediation.ts for the contracts
-  // (an ecosystem that genuinely lacks a mechanism keeps a PERMANENT
-  // exemption with the real reason, like abap.ts).
+  // the mechanism. Contracts: src/languages/capabilities/remediation.ts.
+  // Worked examples, one per capability shape:
+  //   - node-remediation.ts: the full set (manifest text edit for the pin,
+  //     registry probe + install for declare, resync riding installStrategy)
+  //   - python-remediation.ts: TOML text surgery, a custom version grammar,
+  //     and probeInfrastructure for ecosystem-specific probe failures
+  //   - go-remediation.ts: the tool-owned pin (kind: 'command'), an
+  //     osvVersion projection, and a resyncLockfile refusal hook
+  //   - jvm-remediation.ts / abap.ts: PERMANENT reasoned exemptions where
+  //     the ecosystem genuinely lacks the mechanism (a reason, never silence)
+  // After filling in (or keeping planned exemptions), regenerate the docs
+  // coverage table: npm run build && npm run docs:remediation-coverage
+  // (test/remediation-coverage-docs.test.ts pins it against the registry).
   remediation: plannedRemediationSupport('${id}'),
 
   // Lint-GATE provider (custom-check flagship): the linter command that gates
@@ -1213,7 +1222,9 @@ const nextSteps = [
   `  9. Add ${id} toolchain install to .github/workflows/ci.yml`,
   ` 10. Document the toolchain requirement in CONTRIBUTING.md "Cross-ecosystem benchmarks"`,
   ` 11. Update README.md ecosystem coverage table + CLAUDE.md path globs for the new language`,
-  `     (Recipe v3 / G5 — bash scripts/check-docs-coverage.sh fails until you do)`,
+  `     (Recipe v3 / G5 — bash scripts/check-docs-coverage.sh fails until you do), and regenerate`,
+  `     the remediation coverage table: npm run build && npm run docs:remediation-coverage`,
+  `     (test/remediation-coverage-docs.test.ts fails until you do)`,
   ` 12. Curate the CHANGELOG.md "[Unreleased]" stub before ship (G6 wrote a placeholder)`,
   '',
   `  Validate: npm run test:run`,

--- a/src-templates/.claude/skills/dxkit-remediate/SKILL.md
+++ b/src-templates/.claude/skills/dxkit-remediate/SKILL.md
@@ -76,6 +76,15 @@ with disclosure). A refused or failed recipe order falls through to the
 agent tier in the same run; when nothing lands for such orders the outcome
 is `recipes-refused`, never a green no-op.
 
+Which orders CAN go recipe-tier is declared per ecosystem by the language
+packs: each pack either provides a recipe capability (lockfile resync,
+transitive pin, declare dependency, lint autofix) or carries a reasoned
+exemption, and exempt orders tier to the agent with the reason disclosed
+in `remediate plan` output. The per-ecosystem coverage table (generated
+from the pack declarations, with every exemption's reason) lives in the
+"Operating the lanes" learn guide (`vyuh-dxkit learn`, or
+`docs/learn/operating-the-lanes.md` in the dxkit repo).
+
 The frame owns the dependency tree (and whatever else a language pack
 declares as a frame-owned invariant): each order prompt tells the agent not
 to edit the lockfile or run installs, and after every agent order and

--- a/src/discovery/remediation-coverage-tables.ts
+++ b/src/discovery/remediation-coverage-tables.ts
@@ -1,0 +1,86 @@
+/**
+ * Registry-emitted remediation coverage table for
+ * `docs/learn/operating-the-lanes.md` (4.4.7 V4).
+ *
+ * Which pack supports which remediation recipe, and why the agent-tier
+ * cells are agent-tier, is a REGISTRY fact: every pack's declarations live
+ * on `LanguageSupport.remediation` (a provider or a reasoned exemption,
+ * never silence). So the table is EMITTED from those declarations into a
+ * marked region, never hand-written (hand-written copies of registry facts
+ * are the README-matrix drift class, the same reasoning as the
+ * policy-guide tables).
+ *
+ * `scripts/generate-remediation-coverage.js` writes the region;
+ * `test/remediation-coverage-docs.test.ts` pins the committed guide
+ * against a fresh render, so a declaration change (or a new pack) that
+ * forgets the regen step fails CI with a pointer to the command.
+ */
+import { LANGUAGES } from '../languages';
+import type { LanguageSupport } from '../languages';
+import {
+  REMEDIATION_CAPABILITY_IDS,
+  type RemediationCapabilityId,
+} from '../languages/capabilities/remediation';
+import { replaceMarkedRegion } from './docs-tables';
+
+export const REMEDIATION_COVERAGE_BEGIN =
+  '<!-- BEGIN GENERATED: remediation-coverage (edit the pack declarations, then: npm run build && npm run docs:remediation-coverage) -->';
+export const REMEDIATION_COVERAGE_END = '<!-- END GENERATED: remediation-coverage -->';
+
+/**
+ * Reader-facing label per capability id, keyed by the full union so a new
+ * capability cannot ship without a docs label (it fails to compile here).
+ */
+export const REMEDIATION_CAPABILITY_LABELS: Record<RemediationCapabilityId, string> = {
+  resyncLockfile: 'lockfile resync',
+  pinTransitive: 'transitive pin',
+  declareDependency: 'declare dependency',
+  lintFix: 'lint autofix',
+};
+
+/**
+ * Render the coverage matrix (pack x capability, `recipe` or `agent tier`)
+ * plus the pack-declared exemption reasons. `packs` is injectable so the
+ * drift test can prove a mutated declaration changes the render.
+ */
+export function renderRemediationCoverage(packs: readonly LanguageSupport[] = LANGUAGES): string {
+  const labels = REMEDIATION_CAPABILITY_IDS.map((id) => REMEDIATION_CAPABILITY_LABELS[id]);
+  const lines = [
+    `| Pack | ${labels.join(' | ')} |`,
+    `|---|${REMEDIATION_CAPABILITY_IDS.map(() => '---').join('|')}|`,
+  ];
+  for (const pack of packs) {
+    const cells = REMEDIATION_CAPABILITY_IDS.map((id) =>
+      pack.remediation[id].kind === 'capability' ? 'recipe' : 'agent tier',
+    );
+    lines.push(`| \`${pack.id}\` | ${cells.join(' | ')} |`);
+  }
+  const exemptions: string[] = [];
+  for (const pack of packs) {
+    for (const id of REMEDIATION_CAPABILITY_IDS) {
+      const declaration = pack.remediation[id];
+      if (declaration.kind === 'exemption') {
+        exemptions.push(
+          `- \`${pack.id}\` ${REMEDIATION_CAPABILITY_LABELS[id]}: ${declaration.reason}`,
+        );
+      }
+    }
+  }
+  if (exemptions.length > 0) {
+    lines.push('', "The agent-tier cells, in each pack's own words:", '', ...exemptions);
+  }
+  return lines.join('\n');
+}
+
+/** Rewrite the guide's generated region from the registry. */
+export function replaceRemediationCoverage(
+  text: string,
+  packs: readonly LanguageSupport[] = LANGUAGES,
+): string {
+  return replaceMarkedRegion(
+    text,
+    REMEDIATION_COVERAGE_BEGIN,
+    REMEDIATION_COVERAGE_END,
+    renderRemediationCoverage(packs),
+  );
+}

--- a/test/languages-contract.test.ts
+++ b/test/languages-contract.test.ts
@@ -11,6 +11,7 @@ import { collectTreeInvariants } from '../src/languages';
 import { defaultResolvedTolerances } from '../src/install/tolerances';
 import { grammarShape } from '../src/ast/grammar-shape';
 import { modelShapeForGrammar } from '../src/ast/grammar-model-shape';
+import { DEFAULT_PIN_VERSIONS } from '../src/languages/capabilities/remediation';
 
 const REQUIRED_IDS: LanguageId[] = ['typescript', 'python', 'go', 'rust', 'csharp'];
 
@@ -1327,6 +1328,69 @@ describe('remediation capabilities: a provider or a reasoned exemption, per pack
       expect(install.bin.length).toBeGreaterThan(0);
       expect(install.args.length).toBeGreaterThan(0);
       expect(install.args.join(' ')).toContain('sample-pkg');
+    });
+
+    it(`${lang.id}: an optional resyncLockfile refusal hook is pure, deterministic, machine-independent`, () => {
+      const declaration = lang.remediation.resyncLockfile;
+      if (declaration.kind !== 'capability') return;
+      const refusal = declaration.provider.refusal;
+      if (refusal === undefined) return;
+      // The hook is a pure fs-read decision: total over an empty root (no
+      // throw), deterministic across calls, and any reason it returns is a
+      // real sentence with no machine path leaking into ledger prose.
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dxkit-remediation-refusal-'));
+      try {
+        const ctx = { cwd: dir, rootDir: '' };
+        let first!: string | null;
+        expect(() => (first = refusal(ctx))).not.toThrow();
+        expect(refusal(ctx)).toBe(first);
+        if (first !== null) {
+          expect(first.length).toBeGreaterThan(0);
+          expect(first).not.toContain(dir);
+        }
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it(`${lang.id}: an optional osvVersion mapper is pure, total, and non-erasing on concrete versions`, () => {
+      const declaration = lang.remediation.pinTransitive;
+      if (declaration.kind !== 'capability') return;
+      const osvVersion = declaration.provider.osvVersion;
+      if (osvVersion === undefined) return;
+      const scheme = declaration.provider.versions ?? DEFAULT_PIN_VERSIONS;
+      for (const v of ['1.2.3', 'v1.2.3', '1.2', '1.2.3.4', '', 'not-a-version']) {
+        let out!: string;
+        expect(
+          () => (out = osvVersion(v)),
+          `${lang.id}: osvVersion(${JSON.stringify(v)})`,
+        ).not.toThrow();
+        expect(osvVersion(v)).toBe(out);
+        // A version the pack can pin must survive the OSV projection: an
+        // empty mapping would turn the $0 pre-check into a silent no-op.
+        if (scheme.concrete(v)) expect(out.length).toBeGreaterThan(0);
+      }
+    });
+
+    it(`${lang.id}: an optional probeInfrastructure classifier is total and false-negative biased`, () => {
+      const declaration = lang.remediation.declareDependency;
+      if (declaration.kind !== 'capability') return;
+      const probe = declaration.provider.probeInfrastructure;
+      if (probe === undefined) return;
+      // Total and deterministic over untrusted output, and a real
+      // not-found must never read as infrastructure (the executor would
+      // retry a typo forever instead of refusing it).
+      for (const output of ['', '\n\n', 'npm error 404 Not Found', 'no matching version found']) {
+        let out!: boolean;
+        expect(
+          () => (out = probe(output)),
+          `${lang.id}: probeInfrastructure(${JSON.stringify(output)})`,
+        ).not.toThrow();
+        expect(probe(output)).toBe(out);
+        expect(out, `${lang.id}: ${JSON.stringify(output)} must not read as infrastructure`).toBe(
+          false,
+        );
+      }
     });
   }
 });

--- a/test/remediation-coverage-docs.test.ts
+++ b/test/remediation-coverage-docs.test.ts
@@ -39,7 +39,7 @@ describe('remediation coverage table is emitted, never hand-written', () => {
     expect(guide).toContain(REMEDIATION_COVERAGE_END);
   });
 
-  it('committed guide matches a fresh render — if this fails: npm run build && npm run docs:remediation-coverage', () => {
+  it('committed guide matches a fresh render (if this fails: npm run build && npm run docs:remediation-coverage)', () => {
     expect(normalize(replaceRemediationCoverage(guide))).toBe(normalize(guide));
   });
 

--- a/test/remediation-coverage-docs.test.ts
+++ b/test/remediation-coverage-docs.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { LANGUAGES } from '../src/languages';
+import type { LanguageSupport } from '../src/languages';
+import {
+  renderRemediationCoverage,
+  replaceRemediationCoverage,
+  REMEDIATION_CAPABILITY_LABELS,
+  REMEDIATION_COVERAGE_BEGIN,
+  REMEDIATION_COVERAGE_END,
+} from '../src/discovery/remediation-coverage-tables';
+import { REMEDIATION_CAPABILITY_IDS } from '../src/languages/capabilities/remediation';
+
+/**
+ * The remediation coverage table in the lanes guide is EMITTED from the
+ * pack declarations (4.4.7 V4), never hand-maintained: the committed
+ * region must match a fresh render, so a declaration change (or a new
+ * pack) that forgets `npm run build && npm run docs:remediation-coverage`
+ * fails here with the command named. The mutation test proves the pin
+ * itself bites: a changed declaration MUST change the render, otherwise
+ * this file would pass on a renderer that stopped reading the registry.
+ */
+
+const guidePath = join(__dirname, '..', 'docs', 'learn', 'operating-the-lanes.md');
+const guide = readFileSync(guidePath, 'utf8');
+
+/** Prettier reflows table padding; compare content, not padding (the same
+ *  normalization the policy-guide pin uses). */
+const normalize = (s: string) =>
+  s
+    .replace(/-{3,}/g, '---')
+    .replace(/[ \t]*\|[ \t]*/g, '|')
+    .replace(/[ \t]+/g, ' ');
+
+describe('remediation coverage table is emitted, never hand-written', () => {
+  it('the guide carries the generated region markers', () => {
+    expect(guide).toContain(REMEDIATION_COVERAGE_BEGIN);
+    expect(guide).toContain(REMEDIATION_COVERAGE_END);
+  });
+
+  it('committed guide matches a fresh render — if this fails: npm run build && npm run docs:remediation-coverage', () => {
+    expect(normalize(replaceRemediationCoverage(guide))).toBe(normalize(guide));
+  });
+
+  it('every registered pack has a row and every capability a column', () => {
+    const table = renderRemediationCoverage();
+    for (const lang of LANGUAGES) expect(table).toContain(`| \`${lang.id}\` |`);
+    for (const id of REMEDIATION_CAPABILITY_IDS) {
+      expect(table).toContain(REMEDIATION_CAPABILITY_LABELS[id]);
+    }
+  });
+
+  it('every declared exemption reason reaches the guide verbatim', () => {
+    for (const lang of LANGUAGES) {
+      for (const id of REMEDIATION_CAPABILITY_IDS) {
+        const declaration = lang.remediation[id];
+        if (declaration.kind === 'exemption') {
+          expect(guide, `${lang.id}.${id} reason missing from the guide`).toContain(
+            declaration.reason,
+          );
+        }
+      }
+    }
+  });
+
+  it('the pin bites: a mutated declaration changes the render', () => {
+    const [first, ...rest] = LANGUAGES;
+    const mutated: LanguageSupport = {
+      ...first,
+      remediation: {
+        ...first.remediation,
+        resyncLockfile: {
+          kind: 'exemption',
+          reason: 'synthetic mutation: this sentence must change the rendered table',
+        },
+      },
+    };
+    const fresh = replaceRemediationCoverage(guide, [mutated, ...rest]);
+    expect(normalize(fresh)).not.toBe(normalize(guide));
+    expect(fresh).toContain('synthetic mutation: this sentence must change the rendered table');
+  });
+});

--- a/test/scaffold-language.test.ts
+++ b/test/scaffold-language.test.ts
@@ -50,6 +50,18 @@ describe('scaffold-language emits a compiling pack', () => {
       expect(packSrc).toContain(
         "import { plannedRemediationSupport } from './capabilities/remediation';",
       );
+      // The remediation TODO points a new pack author at the real
+      // per-capability exemplars, the exemption pattern, and the generated
+      // docs coverage table regen step (4.4.7 V4).
+      for (const pointer of [
+        'node-remediation',
+        'python-remediation',
+        'go-remediation',
+        'jvm-remediation',
+        'docs:remediation-coverage',
+      ]) {
+        expect(packSrc, `scaffold TODO should point at ${pointer}`).toContain(pointer);
+      }
       // The scaffolder extended the copied union, so `id: 'zetalang'` types.
       const types = fs.readFileSync(path.join(root, 'src', 'types.ts'), 'utf8');
       expect(types).toMatch(/LanguageId[^;]*'zetalang'/);


### PR DESCRIPTION
## What

The 4.4.7 V4 nets-and-docs unit for the remediation capability seam. No behavior changes to executors or packs.

1. **Generated per-ecosystem coverage table.** `docs/learn/operating-the-lanes.md` gains a "Recipe coverage per ecosystem" section whose table (pack x capability, recipe vs agent tier, plus every pack-declared exemption reason verbatim) is emitted from `LanguageSupport.remediation` via a new render module `src/discovery/remediation-coverage-tables.ts`, following the policy-guide-tables idiom: a marked region, `npm run docs:remediation-coverage` (new script `scripts/generate-remediation-coverage.js`) rewrites it from the built registry, and `test/remediation-coverage-docs.test.ts` pins committed == fresh render so drift fails CI with the command named. A mutation test proves the pin bites: mutating a declaration in memory changes the render.
2. **Contract-net gap fills** in `test/languages-contract.test.ts` for the three optional hooks the waves added, so a future pack inherits the discipline cross-cuttingly: `resyncLockfile.refusal` (pure, deterministic, no machine path in the reason), `pinTransitive.osvVersion` (total, deterministic, non-erasing on versions the pack's grammar can pin), `declareDependency.probeInfrastructure` (total over untrusted output, false-negative biased: a real not-found never reads as infrastructure).
3. **Scaffold pointers.** The `new-lang` remediation TODO now names the real per-capability exemplars (node-remediation: the full set; python-remediation: TOML surgery, custom version grammar, probeInfrastructure; go-remediation: tool-owned pin, refusal hook, osvVersion; jvm-remediation/abap: permanent reasoned exemptions) and the docs regen step; the next-steps checklist picks up the regen too, and the scaffold-compile test pins the pointers.
4. **Docs.** CONTRIBUTING's "What the pack declares" gains the remediation bullet (declare-or-exempt, the scaffold path, the generated table's location + regen command); the dxkit-remediate skill and the lanes guide tell operators recipe coverage is pack-declared and where the table lives.

## Why

The design's Future-proofing section: the coverage table must be generated from the pack declarations, never hand-maintained, and the contract nets must catch a future pack or seam change violating the declare-or-exempt discipline. The seam, the executors, and all 11 packs' declarations landed in V1..V3; this unit adds the cross-cutting nets those waves' per-pack tests do not cover.

## How it is tested

- `test/remediation-coverage-docs.test.ts` (new): region markers present, committed guide == fresh render, every pack has a row and every capability a column, every exemption reason reaches the guide verbatim, and the mutation test (a changed declaration must change the render, so the pin cannot pass on a renderer that stopped reading the registry).
- `test/languages-contract.test.ts`: three new per-pack nets for the optional hooks (skip cleanly on packs without the hook; today they exercise go's refusal + osvVersion and python's probeInfrastructure, and bind every future pack).
- `test/scaffold-language.test.ts`: pins the exemplar pointers and the regen-step pointer in the emitted pack.

## Sweep + guardrail

- typecheck, typecheck:test, eslint --max-warnings 0, prettier --check: all green
- check-architecture.sh, check-docs-coverage.sh, check-slop.sh (base origin/main): all green
- build, vitest run --coverage: 437 files, 6721 tests, all passed; coverage 75.72% (threshold 50%)
- `guardrail check --mode ref-based --ref origin/main`: PASSED, exit 0 (0 blocking; the flow-gate no-served-truth notice is this repo's standing configuration note)

## Review focus

- The exemption-reasons list renders every reason verbatim under the table; check the length reads acceptably in the guide (11 packs, 24 exemption bullets today) versus summarizing per capability.
- The contract net asserts `probeInfrastructure` returns false for empty output and 404-shaped output; confirm that bias matches the seam's intent for future ecosystems.
- Placement of the generated region (lanes guide only, with the skill and CONTRIBUTING linking to it) versus also mirroring it into the policy guide.

Deliberately left out: no lint-autofix capability-direction addition to the synthetic playbook pack (the exemption direction is what the playbook proves for lintFix; the capability direction is covered by `test/remediate/recipes/lint-autofix.test.ts` and the wave tests), and no arch-check grep rule for the table (the parity test is the idiom every other generated-docs surface uses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
